### PR TITLE
Add langchain-community requirement to make it build again

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 langchain
+langchain-community
 openai==0.28
 chromadb
 pysqlite3-binary


### PR DESCRIPTION
Build failed due to missing langchain-community package in requirements.txt.