### PR TITLE
Fix get_avatar call parameters, missing stablediffusion_api_base and duckduck go search limit rate problem

### DIFF
--- a/main.py
+++ b/main.py
@@ -155,7 +155,7 @@ chroma_client = Chroma(collection_name="memories", persist_directory="db", embed
 
 # Function to create images with LocalAI
 def display_avatar(agi, input_text=STABLEDIFFUSION_PROMPT, model=STABLEDIFFUSION_MODEL):
-    image_url = agi.get_avatar(input_text, model)
+    image_url = agi.get_avatar(input_text)
     # convert the image to ascii art
     my_art = AsciiArt.from_url(image_url)
     my_art.to_terminal()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pysqlite3-binary
 requests
 ascii-magic
 loguru
-duckduckgo_search==4.1.1
+duckduckgo_search==6.1.7

--- a/src/localagi/localagi.py
+++ b/src/localagi/localagi.py
@@ -74,7 +74,7 @@ class LocalAGI:
             prompt=input_text,
             n=1,
             size="128x128",
-            api_base=self.sta+"/v1"
+            api_base=self.stablediffusion_api_base+"/v1"
         )
         return response['data'][0]['url']
 


### PR DESCRIPTION
- The model parameter is triggering a parameter error, and isn't used in the function, removing it makes image generation got past the parameter error.
- The missing stablediffusion_api_base seems to have lacked some chars :)
- When the search step appeared, it failed with a `rate limit` error, updating the module fixes that

With the commits, LocalAGI did create an avatar and displayed in in the terminal as well as successfully planned a trip.