### PR TITLE
feat(ui): Structured observability/status view

### DIFF
--- a/core/action/state.go
+++ b/core/action/state.go
@@ -2,7 +2,6 @@ package action
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/mudler/LocalAGI/core/types"
 	"github.com/sashabaranov/go-openai/jsonschema"
@@ -15,24 +14,6 @@ func NewState() *StateAction {
 }
 
 type StateAction struct{}
-
-// State is the structure
-// that is used to keep track of the current state
-// and the Agent's short memory that it can update
-// Besides a long term memory that is accessible by the agent (With vector database),
-// And a context memory (that is always powered by a vector database),
-// this memory is the shorter one that the LLM keeps across conversation and across its
-// reasoning process's and life time.
-// TODO: A special action is then used to let the LLM itself update its memory
-// periodically during self-processing, and the same action is ALSO exposed
-// during the conversation to let the user put for example, a new goal to the agent.
-type AgentInternalState struct {
-	NowDoing    string   `json:"doing_now"`
-	DoingNext   string   `json:"doing_next"`
-	DoneHistory []string `json:"done_history"`
-	Memories    []string `json:"memories"`
-	Goal        string   `json:"goal"`
-}
 
 func (a *StateAction) Run(context.Context, types.ActionParams) (types.ActionResult, error) {
 	return types.ActionResult{Result: "internal state has been updated"}, nil
@@ -75,24 +56,4 @@ func (a *StateAction) Definition() types.ActionDefinition {
 			},
 		},
 	}
-}
-
-const fmtT = `=====================
-NowDoing: %s
-DoingNext: %s
-Your current goal is: %s
-You have done: %+v
-You have a short memory with: %+v
-=====================
-`
-
-func (c AgentInternalState) String() string {
-	return fmt.Sprintf(
-		fmtT,
-		c.NowDoing,
-		c.DoingNext,
-		c.Goal,
-		c.DoneHistory,
-		c.Memories,
-	)
 }

--- a/core/agent/observer.go
+++ b/core/agent/observer.go
@@ -1,0 +1,87 @@
+package agent
+
+import (
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+
+	"github.com/mudler/LocalAGI/core/sse"
+	"github.com/mudler/LocalAGI/core/types"
+	"github.com/mudler/LocalAGI/pkg/xlog"
+)
+
+type Observer interface {
+	NewObservable() *types.Observable
+	Update(types.Observable)
+	History() []types.Observable
+}
+
+type SSEObserver struct {
+	agent   string
+	maxID   int32
+	manager sse.Manager
+
+	mutex sync.Mutex
+	history []types.Observable
+	historyLast int
+}
+
+func NewSSEObserver(agent string, manager sse.Manager) *SSEObserver {
+	return &SSEObserver{
+		agent:   agent,
+		maxID:   1,
+		manager: manager,
+		history: make([]types.Observable, 100),
+	}
+}
+
+func (s *SSEObserver) NewObservable() *types.Observable {
+	id := atomic.AddInt32(&s.maxID, 1)
+	return &types.Observable{
+		ID:    id - 1,
+		Agent: s.agent,
+	}
+}
+
+func (s *SSEObserver) Update(obs types.Observable) {
+	data, err := json.Marshal(obs)
+	if err != nil {
+		xlog.Error("Error marshaling observable", "error", err)
+		return
+	}
+	msg := sse.NewMessage(string(data)).WithEvent("observable_update")
+	s.manager.Send(msg)
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	for i, o := range s.history {
+		if o.ID == obs.ID {
+			s.history[i] = obs
+			return
+		}
+	}
+
+	s.history[s.historyLast] = obs
+	s.historyLast += 1
+	if s.historyLast >= len(s.history) {
+		s.historyLast = 0
+	}
+}
+
+func (s *SSEObserver) History() []types.Observable {
+	h := make([]types.Observable, 0, 20)
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	for _, obs := range s.history {
+		if obs.ID == 0 {
+			continue
+		}
+
+		h = append(h, obs)
+	}
+
+	return h
+}

--- a/core/agent/options.go
+++ b/core/agent/options.go
@@ -53,6 +53,8 @@ type options struct {
 	mcpServers []MCPServer
 
 	newConversationsSubscribers []func(openai.ChatCompletionMessage)
+
+	observer Observer
 }
 
 func (o *options) SeparatedMultimodalModel() bool {
@@ -333,6 +335,13 @@ func WithRandomIdentity(guidance ...string) Option {
 func WithActions(actions ...types.Action) Option {
 	return func(o *options) error {
 		o.userActions = actions
+		return nil
+	}
+}
+
+func WithObserver(observer Observer) Option {
+	return func(o *options) error {
+		o.observer = observer
 		return nil
 	}
 }

--- a/core/agent/state.go
+++ b/core/agent/state.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/mudler/LocalAGI/core/action"
+	"github.com/mudler/LocalAGI/core/types"
 	"github.com/sashabaranov/go-openai/jsonschema"
 )
 
@@ -15,7 +15,7 @@ import (
 // in the prompts
 type PromptHUD struct {
 	Character     Character                 `json:"character"`
-	CurrentState  action.AgentInternalState `json:"current_state"`
+	CurrentState  types.AgentInternalState `json:"current_state"`
 	PermanentGoal string                    `json:"permanent_goal"`
 	ShowCharacter bool                      `json:"show_character"`
 }
@@ -80,7 +80,7 @@ func Load(path string) (*Character, error) {
 	return &c, nil
 }
 
-func (a *Agent) State() action.AgentInternalState {
+func (a *Agent) State() types.AgentInternalState {
 	return *a.currentState
 }
 

--- a/core/state/pool.go
+++ b/core/state/pool.go
@@ -407,6 +407,7 @@ func (a *AgentPool) startAgentWithConfig(name string, config *AgentConfig) error
 				c.AgentResultCallback()(state)
 			}
 		}),
+		WithObserver(NewSSEObserver(name, manager)),
 	}
 
 	if config.HUD {

--- a/core/types/job.go
+++ b/core/types/job.go
@@ -27,6 +27,8 @@ type Job struct {
 
 	context context.Context
 	cancel  context.CancelFunc
+
+	Obs *Observable
 }
 
 type ActionRequest struct {
@@ -197,4 +199,10 @@ func (j *Job) Cancel() {
 
 func (j *Job) GetContext() context.Context {
 	return j.context
+}
+
+func WithObservable(obs *Observable) JobOption {
+	return func(j *Job) {
+		j.Obs = obs
+	}
 }

--- a/core/types/observable.go
+++ b/core/types/observable.go
@@ -1,0 +1,61 @@
+package types
+
+import (
+	"github.com/mudler/LocalAGI/pkg/xlog"
+	"github.com/sashabaranov/go-openai"
+)
+
+type Creation struct {
+	ChatCompletionRequest *openai.ChatCompletionRequest `json:"chat_completion_request,omitempty"`
+	FunctionDefinition    *openai.FunctionDefinition    `json:"function_definition,omitempty"`
+	FunctionParams        ActionParams                  `json:"function_params,omitempty"`
+}
+
+type Progress struct {
+	Error                  string                         `json:"error,omitempty"`
+	ChatCompletionResponse *openai.ChatCompletionResponse `json:"chat_completion_response,omitempty"`
+	ActionResult           string                         `json:"action_result,omitempty"`
+	AgentState             *AgentInternalState            `json:"agent_state"`
+}
+
+type Completion struct {
+	Error                  string                         `json:"error,omitempty"`
+	ChatCompletionResponse *openai.ChatCompletionResponse `json:"chat_completion_response,omitempty"`
+	Conversation           []openai.ChatCompletionMessage `json:"conversation,omitempty"`
+	ActionResult           string                         `json:"action_result,omitempty"`
+	AgentState             *AgentInternalState            `json:"agent_state"`
+}
+
+type Observable struct {
+	ID       int32  `json:"id"`
+	ParentID int32  `json:"parent_id,omitempty"`
+	Agent    string `json:"agent"`
+	Name     string `json:"name"`
+	Icon     string `json:"icon"`
+
+	Creation   *Creation   `json:"creation,omitempty"`
+	Progress   []Progress  `json:"progress,omitempty"`
+	Completion *Completion `json:"completion,omitempty"`
+}
+
+func (o *Observable) AddProgress(p Progress) {
+	if o.Progress == nil {
+		o.Progress = make([]Progress, 0)
+	}
+	o.Progress = append(o.Progress, p)
+}
+
+func (o *Observable) MakeLastProgressCompletion() {
+	if len(o.Progress) == 0 {
+		xlog.Error("Observable completed without any progress", "id", o.ID, "name", o.Name)
+		return
+	}
+	p := o.Progress[len(o.Progress)-1]
+	o.Progress = o.Progress[:len(o.Progress)-1]
+	o.Completion = &Completion{
+		Error:                  p.Error,
+		ChatCompletionResponse: p.ChatCompletionResponse,
+		ActionResult:           p.ActionResult,
+		AgentState:             p.AgentState,
+	}
+}

--- a/core/types/state.go
+++ b/core/types/state.go
@@ -1,0 +1,41 @@
+package types
+
+import "fmt"
+
+// State is the structure
+// that is used to keep track of the current state
+// and the Agent's short memory that it can update
+// Besides a long term memory that is accessible by the agent (With vector database),
+// And a context memory (that is always powered by a vector database),
+// this memory is the shorter one that the LLM keeps across conversation and across its
+// reasoning process's and life time.
+// TODO: A special action is then used to let the LLM itself update its memory
+// periodically during self-processing, and the same action is ALSO exposed
+// during the conversation to let the user put for example, a new goal to the agent.
+type AgentInternalState struct {
+	NowDoing    string   `json:"doing_now"`
+	DoingNext   string   `json:"doing_next"`
+	DoneHistory []string `json:"done_history"`
+	Memories    []string `json:"memories"`
+	Goal        string   `json:"goal"`
+}
+
+const fmtT = `=====================
+NowDoing: %s
+DoingNext: %s
+Your current goal is: %s
+You have done: %+v
+You have a short memory with: %+v
+=====================
+`
+
+func (c AgentInternalState) String() string {
+	return fmt.Sprintf(
+		fmtT,
+		c.NowDoing,
+		c.DoingNext,
+		c.Goal,
+		c.DoneHistory,
+		c.Memories,
+	)
+}

--- a/webui/app.go
+++ b/webui/app.go
@@ -370,7 +370,7 @@ func (a *App) Chat(pool *state.AgentPool) func(c *fiber.Ctx) error {
 			xlog.Error("Error marshaling status message", "error", err)
 		} else {
 			manager.Send(
-				sse.NewMessage(string(statusData)).WithEvent("json_status"))
+				sse.NewMessage(string(statusData)).WithEvent("json_message_status"))
 		}
 
 		// Process the message asynchronously
@@ -417,7 +417,7 @@ func (a *App) Chat(pool *state.AgentPool) func(c *fiber.Ctx) error {
 				xlog.Error("Error marshaling completed status", "error", err)
 			} else {
 				manager.Send(
-					sse.NewMessage(string(completedData)).WithEvent("json_status"))
+					sse.NewMessage(string(completedData)).WithEvent("json_message_status"))
 			}
 		}()
 

--- a/webui/react-ui/bun.lock
+++ b/webui/react-ui/bun.lock
@@ -4,6 +4,7 @@
     "": {
       "name": "react-ui",
       "dependencies": {
+        "highlight.js": "^11.11.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
       },
@@ -299,6 +300,8 @@
     "globals": ["globals@16.0.0", "", {}, "sha512-iInW14XItCXET01CQFqudPOWP2jYMl7T+QRQT+UNcR/iQncN/F0UNpgd76iFkBPgNQb4+X3LV9tLJYzwh+Gl3A=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 

--- a/webui/react-ui/package.json
+++ b/webui/react-ui/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "highlight.js": "^11.11.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.24.0",

--- a/webui/react-ui/src/App.css
+++ b/webui/react-ui/src/App.css
@@ -1,4 +1,17 @@
 /* Base styles */
+pre.hljs {
+  background-color: var(--medium-bg);
+  padding: 1rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  font-family: 'JetBrains Mono', monospace;
+  line-height: 1.5;
+}
+
+code.json {
+  display: block;
+}
+
 :root {
   --primary: #00ff95;
   --secondary: #ff00b1;
@@ -1994,14 +2007,60 @@ select.form-control {
   text-decoration: none;
 }
 
-.file-button:hover {
-  background: rgba(0, 255, 149, 0.8);
-  transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-}
-
 .file-button i {
   font-size: 16px;
+}
+
+.card {
+  background: var(--medium-bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 15px;
+  margin-bottom: 15px;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
+  background: var(--light-bg);
+}
+
+.spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--primary);
+  border-radius: 50%;
+  border-top-color: transparent;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.expand-button {
+  background: none;
+  border: none;
+  color: var(--primary);
+  cursor: pointer;
+  font-size: 1.2em;
+  padding: 5px;
+  margin-left: 10px;
+  transition: all 0.3s ease;
+}
+
+.expand-button:hover {
+  color: var(--success);
+  transform: scale(1.1);
+}
+
+.expand-button:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--primary);
 }
 
 .selected-file-info {

--- a/webui/react-ui/src/hooks/useSSE.js
+++ b/webui/react-ui/src/hooks/useSSE.js
@@ -63,8 +63,8 @@ export function useSSE(agentName) {
       }
     });
     
-    // Handle 'json_status' event
-    eventSource.addEventListener('json_status', (event) => {
+    // Handle 'json_message_status' event
+    eventSource.addEventListener('json_message_status', (event) => {
       try {
         const data = JSON.parse(event.data);
         const timestamp = data.timestamp || new Date().toISOString();

--- a/webui/react-ui/src/pages/AgentStatus.jsx
+++ b/webui/react-ui/src/pages/AgentStatus.jsx
@@ -1,13 +1,22 @@
 import { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
+import hljs from 'highlight.js/lib/core';
+import json from 'highlight.js/lib/languages/json';
+import 'highlight.js/styles/monokai.css';
+
+hljs.registerLanguage('json', json);
 
 function AgentStatus() {
+  const [showStatus, setShowStatus] = useState(true);
   const { name } = useParams();
   const [statusData, setStatusData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [_eventSource, setEventSource] = useState(null);
-  const [liveUpdates, setLiveUpdates] = useState([]);
+  // Store all observables by id
+  const [observableMap, setObservableMap] = useState({});
+  const [observableTree, setObservableTree] = useState([]);
+  const [expandedCards, setExpandedCards] = useState(new Map());
 
   // Update document title
   useEffect(() => {
@@ -39,17 +48,80 @@ function AgentStatus() {
 
     fetchStatusData();
 
+    // Helper to build observable tree from map
+    function buildObservableTree(map) {
+      const nodes = Object.values(map);
+      const nodeMap = {};
+      nodes.forEach(node => { nodeMap[node.id] = { ...node, children: [] }; });
+      const roots = [];
+      nodes.forEach(node => {
+        if (!node.parent_id) {
+          roots.push(nodeMap[node.id]);
+        } else if (nodeMap[node.parent_id]) {
+          nodeMap[node.parent_id].children.push(nodeMap[node.id]);
+        }
+      });
+      return roots;
+    }
+
+    // Fetch initial observable history
+    const fetchObservables = async () => {
+      try {
+        const response = await fetch(`/api/agent/${name}/observables`);
+        if (!response.ok) return;
+        const data = await response.json();
+        if (Array.isArray(data.History)) {
+          const map = {};
+          data.History.forEach(obs => {
+            map[obs.id] = obs;
+          });
+          setObservableMap(map);
+          setObservableTree(buildObservableTree(map));
+        }
+      } catch (err) {
+        // Ignore errors for now
+      }
+    };
+    fetchObservables();
+
     // Setup SSE connection for live updates
     const sse = new EventSource(`/sse/${name}`);
     setEventSource(sse);
 
+    sse.addEventListener('observable_update', (event) => {
+      const data = JSON.parse(event.data);
+      console.log(data);
+      setObservableMap(prevMap => {
+        const prev = prevMap[data.id] || {};
+        const updated = {
+          ...prev,
+          ...data,
+          creation: data.creation,
+          progress: data.progress,
+          completion: data.completion,
+          // children are always built client-side
+        };
+        const newMap = { ...prevMap, [data.id]: updated };
+        setObservableTree(buildObservableTree(newMap));
+        return newMap;
+      });
+    });
+
+    // Listen for status events and append to statusData.History
     sse.addEventListener('status', (event) => {
-      try {
-        const data = JSON.parse(event.data);
-        setLiveUpdates(prev => [data, ...prev.slice(0, 19)]); // Keep last 20 updates
-      } catch (err) {
-        setLiveUpdates(prev => [event.data, ...prev.slice(0, 19)]);
-      }
+      const status = event.data;
+      setStatusData(prev => {
+        // If prev is null, start a new object
+        if (!prev || typeof prev !== 'object') {
+          return { History: [status] };
+        }
+        // If History not present, add it
+        if (!Array.isArray(prev.History)) {
+          return { ...prev, History: [status] };
+        }
+        // Otherwise, append
+        return { ...prev, History: [...prev.History, status] };
+      });
     });
 
     sse.onerror = (err) => {
@@ -69,7 +141,7 @@ function AgentStatus() {
     if (value === null || value === undefined) {
       return 'N/A';
     }
-    
+
     if (typeof value === 'object') {
       try {
         return JSON.stringify(value, null, 2);
@@ -77,14 +149,14 @@ function AgentStatus() {
         return '[Complex Object]';
       }
     }
-    
+
     return String(value);
   };
 
   if (loading) {
     return (
-      <div className="loading-container">
-        <div className="loader"></div>
+      <div>
+        <div></div>
         <p>Loading agent status...</p>
       </div>
     );
@@ -92,56 +164,199 @@ function AgentStatus() {
 
   if (error) {
     return (
-      <div className="error-container">
+      <div>
         <h2>Error</h2>
         <p>{error}</p>
-        <Link to="/agents" className="back-btn">
+        <Link to="/agents">
           <i className="fas fa-arrow-left"></i> Back to Agents
         </Link>
       </div>
     );
   }
 
-  // Combine live updates with history
-  const allUpdates = [...liveUpdates, ...(statusData?.History || [])];
-
   return (
-    <div className="agent-status-container">
-      <header className="page-header">
-        <div className="header-content">
-          <h1>
-            <Link to="/agents" className="back-link">
-              <i className="fas fa-arrow-left"></i>
-            </Link>
-            Agent Status: {name}
-          </h1>
+    <div>
+      <h1>Agent Status: {name}</h1>
+      <div style={{ color: '#aaa', fontSize: 16, marginBottom: 18 }}>
+        See what the agent is doing and thinking
+      </div>
+      {error && (
+        <div>
+          {error}
         </div>
-      </header>
+      )}
+      {loading && <div>Loading...</div>}
+      {statusData && (
+        <div>
+          <div>
+            <div style={{ display: 'flex', alignItems: 'center', cursor: 'pointer', userSelect: 'none' }}
+              onClick={() => setShowStatus(prev => !prev)}>
+              <h2 style={{ margin: 0 }}>Current Status</h2>
+              <i
+                className={`fas fa-chevron-${showStatus ? 'up' : 'down'}`}
+                style={{ color: 'var(--primary)', marginLeft: 12 }}
+                title={showStatus ? 'Collapse' : 'Expand'}
+              />
+            </div>
+            <div style={{ color: '#aaa', fontSize: 14, margin: '5px 0 10px 2px' }}>
+              Summary of the agent's thoughts and actions
+            </div>
+            {showStatus && (
+              <div style={{ marginTop: 10 }}>
+                {(Array.isArray(statusData?.History) && statusData.History.length === 0) && (
+                  <div style={{ color: '#aaa' }}>No status history available.</div>
+                )}
+                {Array.isArray(statusData?.History) && statusData.History.map((item, idx) => (
+                  <div key={idx} style={{
+                    background: '#222',
+                    border: '1px solid #444',
+                    borderRadius: 8,
+                    padding: '12px 16px',
+                    marginBottom: 10,
+                    whiteSpace: 'pre-line',
+                    fontFamily: 'inherit',
+                    fontSize: 15,
+                    color: '#eee',
+                  }}>
+                    {/* Replace <br> tags with newlines, then render as pre-line */}
+                    {typeof item === 'string'
+                      ? item.replace(/<br\s*\/?>/gi, '\n')
+                      : JSON.stringify(item)}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+          {observableTree.length > 0 && (
+            <div>
+              <h2>Observable Updates</h2>
+              <div style={{ color: '#aaa', fontSize: 14, margin: '5px 0 10px 2px' }}>
+                Drill down into what the agent is doing and thinking when activated by a connector
+              </div>
+              <div>
+                {observableTree.map((container, idx) => (
+                  <div key={container.id || idx} className='card' style={{ marginBottom: '1em' }}>
+                    <div>
+                      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', cursor: 'pointer' }}
+                        onClick={() => {
+                          const newExpanded = !expandedCards.get(container.id);
+                          setExpandedCards(new Map(expandedCards).set(container.id, newExpanded));
+                        }}
+                      >
+                        <div style={{ display: 'flex', gap: '10px', alignItems: 'center' }}>
+  <i className={`fas fa-${container.icon || 'robot'}`} style={{ verticalAlign: '-0.125em' }}></i>
+  <span>
+    <span className='stat-label'>{container.name}</span>#<span className='stat-label'>{container.id}</span>
+  </span>
+</div>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                          <i
+                            className={`fas fa-chevron-${expandedCards.get(container.id) ? 'up' : 'down'}`}
+                            style={{ color: 'var(--primary)' }}
+                            title='Toggle details'
+                          />
+                          {!container.completion && (
+                            <div className='spinner' />
+                          )}
+                        </div>
+                      </div>
+                      <div style={{ display: expandedCards.get(container.id) ? 'block' : 'none' }}>
+                        {container.children && container.children.length > 0 && (
 
-      <div className="chat-container bg-gray-800 shadow-lg rounded-lg">
-        {/* Chat Messages */}
-        <div className="chat-messages p-4">
-          {allUpdates.length > 0 ? (
-            allUpdates.map((item, index) => (
-              <div key={index} className="status-item mb-4">
-                <div className="bg-gray-700 p-4 rounded-lg">
-                  <h2 className="text-sm font-semibold mb-2">Agent Action:</h2>
-                  <div className="status-details">
-                    <div className="status-row">
-                      <span className="status-label">{index}</span>
-                      <span className="status-value">{formatValue(item)}</span>
+                          <div style={{ marginLeft: '2em', marginTop: '1em' }}>
+                            <h4>Nested Observables</h4>
+                            {container.children.map(child => {
+                              const childKey = `child-${child.id}`;
+                              const isExpanded = expandedCards.get(childKey);
+                              return (
+                                <div key={`${container.id}-child-${child.id}`} className='card' style={{ background: '#222', marginBottom: '0.5em' }}>
+                                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', cursor: 'pointer' }}
+                                    onClick={() => {
+                                      const newExpanded = !expandedCards.get(childKey);
+                                      setExpandedCards(new Map(expandedCards).set(childKey, newExpanded));
+                                    }}
+                                  >
+                                    <div style={{ display: 'flex', gap: '10px', alignItems: 'center' }}>
+  <i className={`fas fa-${child.icon || 'robot'}`} style={{ verticalAlign: '-0.125em' }}></i>
+  <span>
+    <span className='stat-label'>{child.name}</span>#<span className='stat-label'>{child.id}</span>
+  </span>
+</div>
+                                    <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                                      <i
+                                        className={`fas fa-chevron-${isExpanded ? 'up' : 'down'}`}
+                                        style={{ color: 'var(--primary)' }}
+                                        title='Toggle details'
+                                      />
+                                      {!child.completion && (
+                                        <div className='spinner' />
+                                      )}
+                                    </div>
+                                  </div>
+                                  <div style={{ display: isExpanded ? 'block' : 'none' }}>
+                                    {child.creation && (
+                                      <div>
+                                        <h5>Creation:</h5>
+                                        <pre className="hljs"><code>
+                                          <div dangerouslySetInnerHTML={{ __html: hljs.highlight(JSON.stringify(child.creation || {}, null, 2), { language: 'json' }).value }}></div>
+                                        </code></pre>
+                                      </div>
+                                    )}
+                                    {child.progress && child.progress.length > 0 && (
+                                      <div>
+                                        <h5>Progress:</h5>
+                                        <pre className="hljs"><code>
+                                          <div dangerouslySetInnerHTML={{ __html: hljs.highlight(JSON.stringify(child.progress || {}, null, 2), { language: 'json' }).value }}></div>
+                                        </code></pre>
+                                      </div>
+                                    )}
+                                    {child.completion && (
+                                      <div>
+                                        <h5>Completion:</h5>
+                                        <pre className="hljs"><code>
+                                          <div dangerouslySetInnerHTML={{ __html: hljs.highlight(JSON.stringify(child.completion || {}, null, 2), { language: 'json' }).value }}></div>
+                                        </code></pre>
+                                      </div>
+                                    )}
+                                  </div>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        )}
+                        {container.creation && (
+                          <div>
+                            <h4>Creation:</h4>
+                            <pre className="hljs"><code>
+                              <div dangerouslySetInnerHTML={{ __html: hljs.highlight(JSON.stringify(container.creation || {}, null, 2), { language: 'json' }).value }}></div>
+                            </code></pre>
+                          </div>
+                        )}
+                        {container.progress && container.progress.length > 0 && (
+                          <div>
+                            <h4>Progress:</h4>
+                            <pre className="hljs"><code>
+                              <div dangerouslySetInnerHTML={{ __html: hljs.highlight(JSON.stringify(container.progress || {}, null, 2), { language: 'json' }).value }}></div>
+                            </code></pre>
+                          </div>
+                        )}
+                        {container.completion && (
+                          <div>
+                            <h4>Completion:</h4>
+                            <pre className="hljs"><code>
+                              <div dangerouslySetInnerHTML={{ __html: hljs.highlight(JSON.stringify(container.completion || {}, null, 2), { language: 'json' }).value }}></div>
+                            </code></pre>
+                          </div>
+                        )}
+                      </div>
                     </div>
                   </div>
-                </div>
+                ))}
               </div>
-            ))
-          ) : (
-            <div className="no-status-data">
-              <p>No status data available for this agent.</p>
             </div>
           )}
         </div>
-      </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
This builds on (or replaces) the status view with structured events.

The idea is that each time the agent performs some action, like making a decision
using the LLM, the UI will show a group of nested boxes that the user can drill
down into.

![Screenshot 2025-04-18 at 15-58-18 Agent Status hal - LocalAGI](https://github.com/user-attachments/assets/78a685f3-9bbb-40fd-be45-aa15c8e489cc)

At the top level are incoming events with trigger the agent and then a series of
actions it has to perform to respond to the event. At the lowest level we have
the actual API requests to LocalAI or a tool. The lower levels will be hidden
by default.

The observable API allows showing what events are in progress and which have
been completed. So that the user can see what asynchronous actions are waiting 
to be completed.

- **refactor(ui): Make message status SSE name more specific**
- **feat(ui): Add structured observability events**

Note that in the end I kept the old statuses, also there is a bunch of information missing and its still difficult to really see what is happening, so there is a bunch that needs to be done on this, but I think it's good enough for a first stab

![image](https://github.com/user-attachments/assets/6554e214-8836-4f80-9ae4-1e987ae5c149)
