### PR TITLE
fix(discord): automatically add 'Bot' prefix to token if missing

### DIFF
--- a/services/connectors/discord.go
+++ b/services/connectors/discord.go
@@ -30,9 +30,15 @@ func NewDiscord(config map[string]string) *Discord {
 		duration = 5 * time.Minute
 	}
 
+	token := config["token"]
+
+	if !strings.HasPrefix(token, "Bot ") {
+		token = "Bot " + token
+	}
+
 	return &Discord{
 		conversationTracker: NewConversationTracker[string](duration),
-		token:               config["token"],
+		token:               token,
 		defaultChannel:      config["defaultChannel"],
 	}
 }


### PR DESCRIPTION
This should fix #79 .

The token should be prefixed with "Bot", however that is confusing in term of UX - with this change we support both (token with or without prefix) as we add it automatically if missing.