### PR TITLE
fix(docker): Add mcpbox server to extended compose files

### DIFF
--- a/docker-compose.intel.yaml
+++ b/docker-compose.intel.yaml
@@ -12,6 +12,11 @@ services:
       - /dev/dri/card1
       - /dev/dri/renderD129
 
+  mcpbox:
+    extends:
+      file: docker-compose.yaml
+      service: mcpbox
+
   localrecall:
     extends:
       file: docker-compose.yaml

--- a/docker-compose.nvidia.yaml
+++ b/docker-compose.nvidia.yaml
@@ -17,6 +17,11 @@ services:
               count: 1
               capabilities: [gpu]
 
+  mcpbox:
+    extends:
+      file: docker-compose.yaml
+      service: mcpbox
+
   localrecall:
     extends:
       file: docker-compose.yaml


### PR DESCRIPTION
Need to specify the service in the extended Docker compose files
