### PR TITLE
chore(mcpbox): use ubuntu:24.04 as base

### DIFF
--- a/Dockerfile.mcpbox
+++ b/Dockerfile.mcpbox
@@ -20,10 +20,10 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o mcpbox ./cmd/mcpbox
 
 # Final stage
-FROM alpine:3.19
+FROM ubuntu:22.04
 
 # Install runtime dependencies
-RUN apk add --no-cache ca-certificates tzdata docker
+RUN apt-get update && apt-get install -y ca-certificates tzdata docker.io bash
 
 # Create non-root user
 #RUN adduser -D -g '' appuser


### PR DESCRIPTION
As much as I love alpine, we will have less issues with ubuntu as majority of mcp stuff works out of the box there.