### PR TITLE
chore(defaults): Enable reasoning by default

### DIFF
--- a/core/state/config.go
+++ b/core/state/config.go
@@ -253,7 +253,7 @@ func NewAgentConfigMeta(
 				Name:         "enable_reasoning",
 				Label:        "Enable Reasoning",
 				Type:         "checkbox",
-				DefaultValue: false,
+				DefaultValue: true,
 				HelpText:     "Enable agent to explain its reasoning process",
 				Tags:         config.Tags{Section: "AdvancedSettings"},
 			},


### PR DESCRIPTION
There is a huge performance improvement (at least with local models) when deep reasoning is enabled