### PR TITLE
fix(playground): convert fieldType number to string for json unmarshalling

### DIFF
--- a/webui/react-ui/src/pages/ActionsPlayground.jsx
+++ b/webui/react-ui/src/pages/ActionsPlayground.jsx
@@ -118,7 +118,7 @@ function ActionsPlayground() {
       if (fieldType === 'checkbox') {
         value = e.target.checked;
       } else if (fieldType === 'number') {
-        value = e.target.value === '' ? '' : Number(e.target.value);
+        value = e.target.value === '' ? '' : String(e.target.value);
       } else {
         value = e.target.value;
       }


### PR DESCRIPTION
I love this project, I noticed there was a json error in the actions playground after changing the number of search results.
This request changes values for fieldType number to String for unmarshalling to avoid the error.