### PR TITLE
feat: email connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,23 @@ Connect to IRC networks:
 ```
 </details>
 
+<details>
+<summary><strong>Email</strong></summary>
+
+```json
+{
+  "smtpServer": "smtp.gmail.com:587",
+  "imapServer": "imap.gmail.com:993",
+  "smtpInsecure": "false",
+  "imapInsecure": "false",
+  "username": "user@gmail.com",
+  "email": "user@gmail.com",
+  "password": "correct-horse-battery-staple",
+  "name": "LogalAGI Agent"
+}
+```
+</details>
+
 ## REST API
 
 <details>

--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/gofiber/utils v1.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/gomarkdown/markdown v0.0.0-20250311123330-531bef5e742b
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/pprof v0.0.0-20250423184734-337e5dd93bb4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,10 @@ require (
 	mvdan.cc/xurls/v2 v2.6.0
 )
 
+require github.com/JohannesKaufmann/dom v0.2.0 // indirect
+
 require (
+	github.com/JohannesKaufmann/html-to-markdown/v2 v2.3.2
 	github.com/PuerkitoBio/goquery v1.10.3 // indirect
 	github.com/andybalholm/brotli v1.1.1 // indirect
 	github.com/andybalholm/cascadia v1.3.3 // indirect
@@ -45,7 +48,8 @@ require (
 	github.com/bytedance/sonic/loader v0.2.4 // indirect
 	github.com/cloudwego/base64x v0.1.5 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
-	github.com/emersion/go-imap v1.2.1 // indirect
+	github.com/emersion/go-imap/v2 v2.0.0-beta.5 // indirect
+	github.com/emersion/go-message v0.18.2 // indirect
 	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6 // indirect
 	github.com/emersion/go-smtp v0.22.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.9 // indirect

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,9 @@ require (
 	github.com/bytedance/sonic/loader v0.2.4 // indirect
 	github.com/cloudwego/base64x v0.1.5 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
+	github.com/emersion/go-imap v1.2.1 // indirect
+	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6 // indirect
+	github.com/emersion/go-smtp v0.22.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.9 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/gin-gonic/gin v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/JohannesKaufmann/dom v0.2.0 h1:1bragmEb19K8lHAqgFgqCpiPCFEZMTXzOIEjuxkUfLQ=
+github.com/JohannesKaufmann/dom v0.2.0/go.mod h1:57iSUl5RKric4bUkgos4zu6Xt5LMHUnw3TF1l5CbGZo=
+github.com/JohannesKaufmann/html-to-markdown/v2 v2.3.2 h1:eeMLttqTjTgILD6no79Ge96V7Wv8pWDfMVn4jy+koIY=
+github.com/JohannesKaufmann/html-to-markdown/v2 v2.3.2/go.mod h1:HtsP+1Fchp4dVvaiIsLHAl/yqL3H1YLwqLC9kNwqQEg=
 github.com/PuerkitoBio/goquery v1.10.3 h1:pFYcNSqHxBD06Fpj/KsbStFRsgRATgnf3LeXiUkhzPo=
 github.com/PuerkitoBio/goquery v1.10.3/go.mod h1:tMUX0zDMHXYlAQk6p35XxQMqMweEKB7iK7iLNd4RH4Y=
 github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
@@ -39,7 +43,11 @@ github.com/donseba/go-htmx v1.12.0 h1:7tESER0uxaqsuGMv3yP3pK1drfBUXM6apG4H7/3+Ig
 github.com/donseba/go-htmx v1.12.0/go.mod h1:8PTAYvNKf8+QYis+DpAsggKz+sa2qljtMgvdAeNBh5s=
 github.com/emersion/go-imap v1.2.1 h1:+s9ZjMEjOB8NzZMVTM3cCenz2JrQIGGo5j1df19WjTA=
 github.com/emersion/go-imap v1.2.1/go.mod h1:Qlx1FSx2FTxjnjWpIlVNEuX+ylerZQNFE5NsmKFSejY=
+github.com/emersion/go-imap/v2 v2.0.0-beta.5 h1:H3858DNmBuXyMK1++YrQIRdpKE1MwBc+ywBtg3n+0wA=
+github.com/emersion/go-imap/v2 v2.0.0-beta.5/go.mod h1:BZTFHsS1hmgBkFlHqbxGLXk2hnRqTItUgwjSSCsYNAk=
 github.com/emersion/go-message v0.15.0/go.mod h1:wQUEfE+38+7EW8p8aZ96ptg6bAb1iwdgej19uXASlE4=
+github.com/emersion/go-message v0.18.2 h1:rl55SQdjd9oJcIoQNhubD2Acs1E6IzlZISRTK7x/Lpg=
+github.com/emersion/go-message v0.18.2/go.mod h1:XpJyL70LwRvq2a8rVbHXikPgKj8+aI0kGdHlg16ibYA=
 github.com/emersion/go-sasl v0.0.0-20200509203442-7bfe0ed36a21/go.mod h1:iL2twTeMvZnrg54ZoPDNfJaJaqy0xIQFuBdrLsmspwQ=
 github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6 h1:oP4q0fw+fOSWn3DfFi4EXdT+B+gTtzx8GC9xsc26Znk=
 github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6/go.mod h1:iL2twTeMvZnrg54ZoPDNfJaJaqy0xIQFuBdrLsmspwQ=

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,15 @@ github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZ
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/donseba/go-htmx v1.12.0 h1:7tESER0uxaqsuGMv3yP3pK1drfBUXM6apG4H7/3+IgE=
 github.com/donseba/go-htmx v1.12.0/go.mod h1:8PTAYvNKf8+QYis+DpAsggKz+sa2qljtMgvdAeNBh5s=
+github.com/emersion/go-imap v1.2.1 h1:+s9ZjMEjOB8NzZMVTM3cCenz2JrQIGGo5j1df19WjTA=
+github.com/emersion/go-imap v1.2.1/go.mod h1:Qlx1FSx2FTxjnjWpIlVNEuX+ylerZQNFE5NsmKFSejY=
+github.com/emersion/go-message v0.15.0/go.mod h1:wQUEfE+38+7EW8p8aZ96ptg6bAb1iwdgej19uXASlE4=
+github.com/emersion/go-sasl v0.0.0-20200509203442-7bfe0ed36a21/go.mod h1:iL2twTeMvZnrg54ZoPDNfJaJaqy0xIQFuBdrLsmspwQ=
+github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6 h1:oP4q0fw+fOSWn3DfFi4EXdT+B+gTtzx8GC9xsc26Znk=
+github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6/go.mod h1:iL2twTeMvZnrg54ZoPDNfJaJaqy0xIQFuBdrLsmspwQ=
+github.com/emersion/go-smtp v0.22.0 h1:/d3HWxkZZ4riB+0kzfoODh9X+xyCrLEezMnAAa1LEMU=
+github.com/emersion/go-smtp v0.22.0/go.mod h1:ZtRRkbTyp2XTHCA+BmyTFTrj8xY4I+b4McvHxCU2gsQ=
+github.com/emersion/go-textwrapper v0.0.0-20200911093747-65d896831594/go.mod h1:aqO8z8wPrjkscevZJFVE1wXJrLpC5LtJG7fqLOsPb2U=
 github.com/eritikass/githubmarkdownconvertergo v0.1.10 h1:mL93ADvYMOeT15DcGtK9AaFFc+RcWcy6kQBC6yS/5f4=
 github.com/eritikass/githubmarkdownconvertergo v0.1.10/go.mod h1:BdpHs6imOtzE5KorbUtKa6bZ0ZBh1yFcrTTAL8FwDKY=
 github.com/gabriel-vasile/mimetype v1.4.9 h1:5k+WDwEsD9eTLL8Tz3L0VnmVh9QxGjRmjBvAG7U/oYY=

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+github.com/gomarkdown/markdown v0.0.0-20250311123330-531bef5e742b h1:EY/KpStFl60qA17CptGXhwfZ+k1sFNJIUNR8DdbcuUk=
+github.com/gomarkdown/markdown v0.0.0-20250311123330-531bef5e742b/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=

--- a/services/connectors.go
+++ b/services/connectors.go
@@ -20,6 +20,7 @@ const (
 	ConnectorGithubPRs    = "github-prs"
 	ConnectorTwitter      = "twitter"
 	ConnectorMatrix       = "matrix"
+	ConnectorEmail        = "email"
 )
 
 var AvailableConnectors = []string{
@@ -31,6 +32,7 @@ var AvailableConnectors = []string{
 	ConnectorGithubPRs,
 	ConnectorTwitter,
 	ConnectorMatrix,
+	ConnectorEmail,
 }
 
 func Connectors(a *state.AgentConfig) []state.Connector {
@@ -70,6 +72,8 @@ func Connectors(a *state.AgentConfig) []state.Connector {
 			conns = append(conns, cc)
 		case ConnectorMatrix:
 			conns = append(conns, connectors.NewMatrix(config))
+		case ConnectorEmail:
+			conns = append(conns, connectors.NewEmail(config))
 		}
 	}
 	return conns
@@ -116,6 +120,11 @@ func ConnectorsConfigMeta() []config.FieldGroup {
 			Name:   "matrix",
 			Label:  "Matrix",
 			Fields: connectors.MatrixConfigMeta(),
+		},
+		{
+			Name:   "email",
+			Label:  "Email",
+			Fields: connectors.EmailConfigMeta(),
 		},
 	}
 }

--- a/services/connectors/email.go
+++ b/services/connectors/email.go
@@ -1,0 +1,116 @@
+package connectors
+
+import (
+	//"fmt"
+	//"strings"
+
+	"github.com/mudler/LocalAGI/core/agent"
+	"github.com/mudler/LocalAGI/core/types"
+	"github.com/mudler/LocalAGI/pkg/config"
+	"github.com/mudler/LocalAGI/pkg/xlog"
+)
+
+type Email struct {
+	username string
+	name     string
+	password string
+	email    string
+	smtpUri  string
+	smtpIns  bool
+	imapUri string
+	imapIns  bool
+}
+
+func NewEmail(config map[string]string) *Email {
+
+	return &Email{
+		username: config["username"],
+		name:     config["name"],
+		password: config["password"],
+		email:    config["email"],
+		smtpUri:  config["smtpUri"],
+		smtpIns:  config["smtpIns"] == "true",
+		imapUri:  config["imapUri"],
+		imapIns:  config["imapIns"] == "true",
+	}
+}
+
+func EmailConfigMeta() []config.Field {
+	return []config.Field{
+		{
+			Name:     "smtpUri",
+			Label:    "SMTP Host:port",
+			Type:     config.FieldTypeText,
+			Required: true,
+			HelpText: "SMTP server host:port (e.g., smtp.gmail.com:587)",
+		},
+		{
+			Name:  "smtpIns",
+			Label: "Insecure SMTP",
+			Type:  config.FieldTypeCheckbox,
+		},
+		{
+			Name:     "imapUri",
+			Label:    "IMAP Host:port",
+			Type:     config.FieldTypeText,
+			Required: true,
+			HelpText: "IMAP server host:port (e.g., imap.gmail.com:993)",
+		},
+		{
+			Name:  "imapIns",
+			Label: "Insecure IMAP",
+			Type:  config.FieldTypeCheckbox,
+		},
+		{
+			Name:     "username",
+			Label:    "Username",
+			Type:     config.FieldTypeText,
+			Required: true,
+			HelpText: "Username/email address",
+		},
+		{
+			Name:     "name",
+			Label:    "Friendly Name",
+			Type:     config.FieldTypeText,
+			Required: true,
+			HelpText: "Friendly name of sender",
+		},
+		{
+			Name:     "password",
+			Label:    "SMTP Password",
+			Type:     config.FieldTypeText,
+			Required: true,
+			HelpText: "SMTP password or app password",
+		},
+		{
+			Name:     "email",
+			Label:    "From Email",
+			Type:     config.FieldTypeText,
+			Required: true,
+			HelpText: "Sender email address",
+		},
+	}
+}
+
+func (e *Email) AgentResultCallback() func(state types.ActionState) {
+	return func(state types.ActionState) {
+		// Send the result to the bot
+	}
+}
+
+func (e *Email) AgentReasoningCallback() func(state types.ActionCurrentState) bool {
+	return func(state types.ActionCurrentState) bool {
+		// Send the reasoning to the bot
+		return true
+	}
+}
+
+func (e *Email) Start(a *agent.Agent) {
+
+	go func() {
+		xlog.Info("Email connector is now running.  Press CTRL-C to exit.")
+		
+		<-a.Context().Done()
+		xlog.Info("Email connector is now stopped.")
+	}()
+}


### PR DESCRIPTION
Inspired by how long some of my agents take to respond, I've created an email provider to match their pace.

# Overview
With the email connector configured, the user can send an email to the agent, and the agent will reply to the user.

# Features
- Support conversational chat (replies)
- Can send and receive HTML emails
- Supports secure and insecure IMAP + SMTP
- Only listens to the email address configured (in case user has multiple emails)
- Markdown is formatted correctly in HTML emails
- Inline images (when the agent outputs them in markdown syntax)

# Not yet implemented
- DKIM signing
- File attachments

# Screenshot
![snapshot_2025-05-14-edit2](https://github.com/user-attachments/assets/ce3c6cca-7ce8-41df-91f8-00ac82bcd2a7)

# Testing
I've created this connector for my own IMAP and SMTP servers, and I don't have any others. I assume others will work but if they do not, I'd be more than happy to work with everyone to get that solved and to get this merged upstream.

Thanks for considering.