### PR TITLE
fix: errored ssh output

### DIFF
--- a/services/actions/shell.go
+++ b/services/actions/shell.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/mudler/LocalAGI/core/types"
 	"github.com/mudler/LocalAGI/pkg/config"
@@ -165,12 +166,15 @@ func sshCommand(privateKey, command, user, host string) (string, error) {
 	defer session.Close()
 
 	// Run a command
-	output, err := session.CombinedOutput(command)
-	if err != nil {
-		return "", fmt.Errorf("failed to run: %v", err)
+	cmdOut, err := session.CombinedOutput(command)
+	result := string(cmdOut)
+	if strings.TrimSpace(result) == "" {
+		result += "\nCommand has exited with no output"
 	}
-
-	return string(output), nil
+	if err != nil {
+		result += "\nError: " + err.Error()
+	}
+	return result, nil
 }
 
 func (a *ShellAction) Plannable() bool {


### PR DESCRIPTION
# Issues fixed
- If command exit code != 0, the command output was never displayed to the agent, only the exit code.
- If a command had no output, agents frequently thought the command never ran. The reasoning will then get stuck in a loop trying to run the same command, even though it's run successfully.