### PR TITLE
fix: use correct env key in panic

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func init() {
 		panic("LOCALAGI_MODEL not set")
 	}
 	if apiURL == "" {
-		panic("LOCALAGI_API_URL not set")
+		panic("LOCALAGI_LLM_API_URL not set")
 	}
 	if timeout == "" {
 		timeout = "5m"


### PR DESCRIPTION
When in a panic, it would be nice to know which env key needs to be corrected. ;)