### PR TITLE
Fix/catch nil panic

### DIFF
--- a/core/agent/actions.go
+++ b/core/agent/actions.go
@@ -236,7 +236,9 @@ func (m Messages) IsLastMessageFromRole(role string) bool {
 }
 
 func (a *Agent) generateParameters(job *types.Job, pickTemplate string, act types.Action, c []openai.ChatCompletionMessage, reasoning string, maxAttempts int) (*decisionResult, error) {
-
+	if act == nil {
+		return nil, fmt.Errorf("action is nil")
+	}
 	if len(act.Definition().Properties) > 0 {
 		xlog.Debug("Action has properties", "action", act.Definition().Name, "properties", act.Definition().Properties)
 	} else {
@@ -363,6 +365,11 @@ func (a *Agent) handlePlanning(ctx context.Context, job *types.Job, chosenAction
 		)
 
 		subTaskAction := a.availableActions().Find(subtask.Action)
+		if subTaskAction == nil {
+			xlog.Error("Action not found: %s", subtask.Action)
+			return conv, fmt.Errorf("action %s not found", subtask.Action)
+		}
+
 		subTaskReasoning := fmt.Sprintf("%s Overall goal is: %s", subtask.Reasoning, planResult.Goal)
 
 		params, err := a.generateParameters(job, pickTemplate, subTaskAction, conv, subTaskReasoning, maxRetries)

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func init() {
 		panic("LOCALAGI_MODEL not set")
 	}
 	if apiURL == "" {
-		panic("LOCALAGI_API_URL not set")
+		panic("LOCALAGI_LLM_API_URL not set")
 	}
 	if timeout == "" {
 		timeout = "5m"


### PR DESCRIPTION
While testing, found a nice crash
```sh
panic: runtime error: invalid memory address or nil pointer dereference                                                                                                                                                         
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xfbb105]                                                                                                                                                         
                                                                                                                                                                                                                                
goroutine 68 [running]:                                                                                                                                                                                                         
github.com/mudler/LocalAGI/core/agent.(*Agent).generateParameters(0xc0005ba800, 0xc000386210, {0x1a0cba8, 0x72f}, {0x0, 0x0}, {0xc0002b8b40, 0x3, 0x3}, {0xc0003202c0, ...}, ...)                                               
        /home/user/LocalAGI/core/agent/actions.go:240 +0x65                                                                                                                                                                     
github.com/mudler/LocalAGI/core/agent.(*Agent).handlePlanning(0xc0005ba800, {0x72f?, 0x1fa0a20?}, 0xc000386210, {0x1fa0a20, 0xc000692528}, 0xc00033d200, {0xc0005b2b00, 0x506}, {0x1a0cba8, ...}, ...)                          
        /home/user/LocalAGI/core/agent/actions.go:368 +0xbae                                                                                                                                                                    
github.com/mudler/LocalAGI/core/agent.(*Agent).consumeJob(0xc0005ba800, 0xc000386210, {0x1986edf, 0x4}, 0x5)                                                                                                                    
        /home/user/LocalAGI/core/agent/agent.go:794 +0x1ef8                                                                                                                                                                     
github.com/mudler/LocalAGI/core/agent.(*Agent).run(0xc0005ba800, 0xc000318070)
        /home/user/LocalAGI/core/agent/agent.go:1182 +0xfd
github.com/mudler/LocalAGI/core/agent.(*Agent).Run.func1()
        /home/user/LocalAGI/core/agent/agent.go:1160 +0x3a
created by github.com/mudler/LocalAGI/core/agent.(*Agent).Run in goroutine 38
        /home/user/LocalAGI/core/agent/agent.go:1159 +0x19b
```
Added a robust `nil` catcher system.