### PR TITLE
Add docker compose for amd gpu

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ docker compose -f docker-compose.nvidia.yaml up
 # Intel GPU setup (for Intel Arc and integrated GPUs)
 docker compose -f docker-compose.intel.yaml up
 
+# AMD GPU setup
+docker compose -f docker-compose.amd.yaml up
+
 # Start with a specific model (see available models in models.localai.io, or localai.io to use any model in huggingface)
 MODEL_NAME=gemma-3-12b-it docker compose up
 

--- a/docker-compose.amd.yaml
+++ b/docker-compose.amd.yaml
@@ -1,0 +1,37 @@
+services:
+  localai:
+    extends:
+      file: docker-compose.yaml
+      service: localai
+    environment:
+      - LOCALAI_SINGLE_ACTIVE_BACKEND=true
+      - DEBUG=true
+    image: localai/localai:master-gpu-hipblas
+    devices:
+      - /dev/dri
+      - /dev/kfd
+
+  mcpbox:
+    extends:
+      file: docker-compose.yaml
+      service: mcpbox
+
+  dind:
+    extends:
+      file: docker-compose.yaml
+      service: dind
+
+  localrecall:
+    extends:
+      file: docker-compose.yaml
+      service: localrecall
+
+  localrecall-healthcheck:
+    extends:
+      file: docker-compose.yaml
+      service: localrecall-healthcheck
+
+  localagi:
+    extends:
+      file: docker-compose.yaml
+      service: localagi


### PR DESCRIPTION
Adding docker-compose.amd.yaml to run easily LocalAGI on AMD gpu. 

I tested it on Archlinux with AMD RX6950XT gpu 