### PR TITLE
fix(ui): Avoid passing object (multimedia message) into React template

### DIFF
--- a/webui/react-ui/src/pages/AgentStatus.jsx
+++ b/webui/react-ui/src/pages/AgentStatus.jsx
@@ -16,6 +16,14 @@ function ObservableSummary({ observable }) {
       creationChatMsg = lastMsg?.content || '';
     }
   }
+
+  // TODO:: Probably we have an array of two objects: [{type:"text", ...}, {type:"image_url", image_url: {url:"..."}}] 
+  //        We could display the image and text along with multimedia icon
+  if (typeof creationChatMsg === 'object') {
+    console.log("Multimedia message?", creationChatMsg);
+    creationChatMsg = 'Multimedia message';
+  }
+
   // FunctionDefinition summary
   let creationFunctionDef = '';
   if (creation?.function_definition?.name) {
@@ -37,7 +45,6 @@ function ObservableSummary({ observable }) {
     chatCompletion = { choices: completion.conversation.map(m => {
       return { message: m }
     }) }
-    console.log("converted conversation to choices", chatCompletion)
   }
 
   if (
@@ -106,7 +113,7 @@ function ObservableSummary({ observable }) {
       !completionAgentState && !completionError && !completionFilter) {
     return null;
   }
-
+  
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 2, margin: '2px 0 0 0' }}>
       {/* CREATION */}
@@ -282,7 +289,6 @@ function AgentStatus() {
 
     sse.addEventListener('observable_update', (event) => {
       const data = JSON.parse(event.data);
-      console.log(data);
       setObservableMap(prevMap => {
         const prev = prevMap[data.id] || {};
         const updated = {


### PR DESCRIPTION
This prevents React from crashing when an image is submitted on its own, but doesn't provide the best UX. Displaying the contents of a multimedia or multi-part message is left to a future PR. Possibly we need to stop using the raw chat completion API output and normalise the messages server side which is beyond the scope of just preventing a crash.
