### PR TITLE
chore: propagate env

### DIFF
--- a/core/action/custom.go
+++ b/core/action/custom.go
@@ -3,6 +3,7 @@ package action
 import (
 	"context"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 
@@ -60,6 +61,7 @@ func (a *CustomAction) initializeInterpreter() error {
 	if _, exists := a.config["code"]; exists && a.i == nil {
 		unsafe := strings.ToLower(a.config["unsafe"]) == "true"
 		i := interp.New(interp.Options{
+			Env:          os.Environ(),
 			GoPath:       a.goPkgPath,
 			Unrestricted: unsafe,
 		})

--- a/services/prompts/custom.go
+++ b/services/prompts/custom.go
@@ -2,6 +2,7 @@ package prompts
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 
@@ -90,6 +91,7 @@ func (a *DynamicCustomPrompt) initializeInterpreter() error {
 		i := interp.New(interp.Options{
 			GoPath:       a.goPkgPath,
 			Unrestricted: unsafe,
+			Env:          os.Environ(),
 		})
 		if err := i.Use(stdlib.Symbols); err != nil {
 			return err


### PR DESCRIPTION
This pull request updates both the custom action and dynamic custom prompt interpreter initialization to ensure environment variables are correctly passed to the interpreter. This improves compatibility and consistency when executing code that relies on environment settings.

Interpreter initialization improvements:

* Added the current environment variables using `os.Environ()` to the interpreter options in `CustomAction` (`core/action/custom.go`). [[1]](diffhunk://#diff-5cbcfdb6ba4c6af9a6083bd465335948981d18178fe8220311883d1db989b193R6) [[2]](diffhunk://#diff-5cbcfdb6ba4c6af9a6083bd465335948981d18178fe8220311883d1db989b193R64)
* Added the current environment variables using `os.Environ()` to the interpreter options in `DynamicCustomPrompt` (`services/prompts/custom.go`). [[1]](diffhunk://#diff-ff0e78b05ad0bc6b4fc6a03cc7e403239830a7eb7394f748c781be0cf00bc740R5) [[2]](diffhunk://#diff-ff0e78b05ad0bc6b4fc6a03cc7e403239830a7eb7394f748c781be0cf00bc740R94)