### PR TITLE
feat(actions/dynamicprompt): allow to pass-by a configuration

### DIFF
--- a/core/action/custom.go
+++ b/core/action/custom.go
@@ -49,12 +49,12 @@ func (a *CustomAction) callInit() error {
 		return nil
 	}
 
-	run, ok := v.Interface().(func() error)
+	run, ok := v.Interface().(func(string) error)
 	if !ok {
 		return nil
 	}
 
-	return run()
+	return run(a.config["configuration"])
 }
 
 func (a *CustomAction) initializeInterpreter() error {
@@ -194,6 +194,12 @@ func CustomConfigMeta() []config.Field {
 			Label:    "Unsafe",
 			Type:     config.FieldTypeCheckbox,
 			HelpText: "Allow unsafe code execution",
+		},
+		{
+			Name:     "configuration",
+			Label:    "Configuration",
+			Type:     config.FieldTypeTextarea,
+			HelpText: "Configuration for the custom action",
 		},
 	}
 }

--- a/core/state/config.go
+++ b/core/state/config.go
@@ -21,7 +21,7 @@ type ActionsConfig struct {
 }
 
 type DynamicPromptsConfig struct {
-	Type   string `json:"type"`
+	Name   string `json:"name"`
 	Config string `json:"config"`
 }
 

--- a/services/actions.go
+++ b/services/actions.go
@@ -60,8 +60,9 @@ const (
 )
 
 const (
-	nameField        = "name"
-	descriptionField = "description"
+	nameField          = "name"
+	descriptionField   = "description"
+	configurationField = "configuration"
 )
 
 var AvailableActions = []string{
@@ -330,6 +331,7 @@ func customActions(customActionsDir string, existingActionConfigs map[string]map
 			// We allow the user to customize name and description
 			actionConfig[descriptionField] = c[descriptionField]
 			actionConfig[nameField] = c[nameField]
+			actionConfig[configurationField] = c[configurationField]
 		}
 		a, err := Action(ActionCustom, "", actionConfig, nil, map[string]string{})
 		if err != nil {
@@ -495,6 +497,12 @@ func ActionsConfigMeta(customActionDir string) []config.FieldGroup {
 						Label:    "Description",
 						Type:     config.FieldTypeTextarea,
 						HelpText: "Description of the custom action",
+					},
+					{
+						Name:     configurationField,
+						Label:    "Configuration",
+						Type:     config.FieldTypeTextarea,
+						HelpText: "Configuration of the custom action",
 					},
 				},
 			})

--- a/services/prompts/custom.go
+++ b/services/prompts/custom.go
@@ -48,9 +48,9 @@ func (a *DynamicCustomPrompt) callInit() error {
 		return nil
 	}
 
-	run := v.Interface().(func() error)
+	run := v.Interface().(func(string) error)
 
-	return run()
+	return run(a.config["configuration"])
 }
 
 func NewDynamicPromptConfigMeta() config.FieldGroup {
@@ -80,6 +80,12 @@ func NewDynamicPromptConfigMeta() config.FieldGroup {
 				Type:     config.FieldTypeCheckbox,
 				Required: false,
 				HelpText: "Enable if the code needs to use unsafe Go features",
+			},
+			{
+				Name:     "configuration",
+				Label:    "Configuration",
+				Type:     config.FieldTypeTextarea,
+				HelpText: "Configuration for the custom prompt",
 			},
 		},
 	}


### PR DESCRIPTION
This is useful mainly to pass-by from the web interface a generic string that can be later re-used in the custom actions or dynamic prompt during Init().

The Signature of the custom actions and prompts around Init has changed, and now is Init(string), this is on the custom action duty to decide if the string is e.g. a JSON, or a comma separated list, etc.