### PR TITLE
Add "Play" button to action configuration for testing in Playground

### DIFF
--- a/webui/react-ui/src/components/ActionForm.jsx
+++ b/webui/react-ui/src/components/ActionForm.jsx
@@ -5,7 +5,7 @@ import ConfigForm from './ConfigForm';
  * ActionForm component for configuring an action
  * Renders action configuration forms based on field group metadata
  */
-const ActionForm = ({ actions = [], onChange, onRemove, onAdd, fieldGroups = [] }) => {
+const ActionForm = ({ actions = [], onChange, onRemove, onAdd, onPlay, fieldGroups = [] }) => {
   const handleActionChange = (index, updatedAction) => {
     onChange(index, updatedAction);
   };
@@ -17,6 +17,7 @@ const ActionForm = ({ actions = [], onChange, onRemove, onAdd, fieldGroups = [] 
       onChange={handleActionChange}
       onRemove={onRemove}
       onAdd={onAdd}
+      onPlay={onPlay}
       itemType="action"
       typeField="name"
       addButtonText="Add Action"

--- a/webui/react-ui/src/components/ConfigForm.jsx
+++ b/webui/react-ui/src/components/ConfigForm.jsx
@@ -10,6 +10,7 @@ import FormFieldDefinition from './common/FormFieldDefinition';
  * @param {Function} props.onChange - Callback when an item changes
  * @param {Function} props.onRemove - Callback when an item is removed
  * @param {Function} props.onAdd - Callback when a new item is added
+ * @param {Function} props.onPlay - Callback when a play button is clicked
  * @param {String} props.itemType - Type of items being configured ('action', 'connector', etc.)
  * @param {String} props.typeField - The field name that determines the item's type (e.g., 'name' for actions, 'type' for connectors)
  * @param {String} props.addButtonText - Text for the add button
@@ -19,8 +20,9 @@ const ConfigForm = ({
   items = [], 
   fieldGroups = [],
   onChange, 
-  onRemove, 
+  onRemove,
   onAdd,
+  onPlay,
   itemType = 'item',
   typeField = 'type',
   addButtonText = 'Add Item',
@@ -89,15 +91,25 @@ const ConfigForm = ({
     
     return (
       <div key={index} className="config-item mb-4 card">
-        <div className="config-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
-          <h4 style={{ margin: 0 }}>{itemTypeLabel} #{index + 1}</h4>
-          <button 
-            type="button" 
-            className="action-btn delete-btn"
-            onClick={() => onRemove(index)}
-          >
-            <i className="fas fa-times"></i>
-          </button>
+        <div className="config-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem', gap: '1rem' }}>
+          <h4 style={{ margin: 0, flex: 1 }}>{itemTypeLabel} #{index + 1}</h4>
+            {/* Render Play button if onPlay handler is provided */}
+            {onPlay && (
+                <button
+                    type="button"
+                    className="action-btn"
+                    onClick={() => onPlay(index)}
+                >
+                    <i className="fas fa-play"></i>
+                </button>
+            )}
+            <button
+                type="button"
+                className="action-btn delete-btn"
+                onClick={() => onRemove(index)}
+            >
+                <i className="fas fa-times"></i>
+            </button>
         </div>
         
         <div className="config-type mb-3">

--- a/webui/react-ui/src/components/agent-form-sections/ActionsSection.jsx
+++ b/webui/react-ui/src/components/agent-form-sections/ActionsSection.jsx
@@ -35,6 +35,18 @@ const ActionsSection = ({ formData, setFormData, metadata }) => {
     });
   };
 
+  // Handle the play button and open the action playground
+  const handleActionPlay = (index) => {
+    const action = formData.actions[index];
+    const searchParams = new URLSearchParams({
+      action: action.name,
+      config: action.config
+    });
+
+    // Open in new tab while staying in React Router context
+    window.open(`/app/actions-playground?${searchParams.toString()}`, '_blank');
+  };
+
   return (
     <div className="actions-section">
       <h3>Actions</h3>
@@ -47,6 +59,7 @@ const ActionsSection = ({ formData, setFormData, metadata }) => {
         onChange={handleActionChange}
         onRemove={handleActionRemove}
         onAdd={handleAddAction}
+        onPlay={handleActionPlay}
         fieldGroups={metadata?.actions || []}
       />
     </div>


### PR DESCRIPTION
This PR adds a "Play" button to the action list in the agent configuration. When clicking it, the actions playground opens in a new window with the action pre-selected and all fields pre-filled.

This allows for easier debugging, because the parameters configured for an action inside an agent don't to be entered again in the playground.

<img width="631" height="164" alt="Screenshot_20251006_210545" src="https://github.com/user-attachments/assets/ac355936-4b0d-4914-85ce-6eb38065fbe0" />
