### PR TITLE
Remove mcpbox service from docker-compose.nvidia.yaml

### DIFF
--- a/docker-compose.nvidia.yaml
+++ b/docker-compose.nvidia.yaml
@@ -17,11 +17,6 @@ services:
               count: 1
               capabilities: [gpu]
 
-  mcpbox:
-    extends:
-      file: docker-compose.yaml
-      service: mcpbox
-    
   dind:
     extends:
       file: docker-compose.yaml


### PR DESCRIPTION
Removed mcpbox service extension from NVIDIA compose file.


Leftover of #318