### PR TITLE
Prevent MCP HTTP/SSE premature connection and support MCP ImageContent responses

### DIFF
--- a/core/agent/agent.go
+++ b/core/agent/agent.go
@@ -1216,7 +1216,7 @@ func (a *Agent) addFunctionResultToConversation(ctx context.Context, chosenActio
 					{
 						Type: openai.ChatMessagePartTypeImageURL,
 						ImageURL: &openai.ChatMessageImageURL{
-							URL: "data:image/png;base64," + result.ImageBase64Result,
+							URL: result.ImageBase64Result,
 						},
 					},
 				},

--- a/core/agent/mcp.go
+++ b/core/agent/mcp.go
@@ -68,7 +68,7 @@ func (m *mcpAction) Run(ctx context.Context, sharedState *types.AgentSharedState
 		case *mcp.TextContent:
 			result += content.Text
 		case *mcp.ImageContent:
-			imageBase64Result = base64.StdEncoding.EncodeToString(content.Data)
+			imageBase64Result = "data:" + content.MIMEType + ";base64," + base64.StdEncoding.EncodeToString(content.Data)
 		default:
 			log.Error().Msgf("[Unknown content type received: %T]", content)
 		}


### PR DESCRIPTION
Prevent MCP HTTP/SSE premature connection and support MCP ImageContent responses

This fixes the issue in v2.6.0, but does not apply to main branch. The functionality has been partially split off into the cogito library in the main branch.

This relates to fixing and enhancing the mcp client.  HTTP/SSE connections are being prematurely closed, so it seems like only STDIO works currently. This will prevent the premature closure of HTTP/SSE connections by the mcp client.

But it looks like, since v2.6.0, functionality has been shifted to cogito library.  The Execute() function in cogito mcp.go has a different signature compared to the Run() function in the LocalAGI mcp.go.  Since the Run() method returns types.ActionResult, it was very easy to support multi-part mcp response with base64 image.  But looking at cogito, the Execute() method returns only a string.  I don't see a proper way to handle the mcp.ImageContent responses yet.