### PR TITLE
HTTP MCP Fixes

### DIFF
--- a/core/agent/agent.go
+++ b/core/agent/agent.go
@@ -270,7 +270,7 @@ func (a *Agent) Stop() {
 	a.Lock()
 	defer a.Unlock()
 	xlog.Debug("Stopping agent", "agent", a.Character.Name)
-	a.closeMCPSTDIOServers()
+	a.closeMCPServers()
 	a.context.Cancel()
 }
 


### PR DESCRIPTION
Add support for Streamable MCP over HTTP - fallback on legacy SSE transport.

Fix: Prevent HTTP MCP servers from being closed immediately after initialization.