### PR TITLE
feat: allow to adjust knowledgebase usage

### DIFF
--- a/core/agent/options.go
+++ b/core/agent/options.go
@@ -30,6 +30,7 @@ type options struct {
 	jobFilters                                                                                   types.JobFilters
 	enableHUD, standaloneJob, showCharacter, enableKB, enableSummaryMemory, enableLongTermMemory bool
 	stripThinkingTags                                                                            bool
+	kbAutoSearch                                                                                  bool
 
 	canStopItself         bool
 	initiateConversations bool
@@ -85,6 +86,7 @@ func defaultOptions() *options {
 		periodicRuns:       15 * time.Minute,
 		maxEvaluationLoops: 2,
 		enableEvaluation:   false,
+		kbAutoSearch:       true, // Default to true to maintain backward compatibility
 		LLMAPI: llmOptions{
 			APIURL:                "http://localhost:8080",
 			Model:                 "gpt-4",
@@ -470,6 +472,13 @@ func WithTranscriptionLanguage(language string) Option {
 func WithTTSModel(model string) Option {
 	return func(o *options) error {
 		o.LLMAPI.TTSModel = model
+		return nil
+	}
+}
+
+func WithKBAutoSearch(enabled bool) Option {
+	return func(o *options) error {
+		o.kbAutoSearch = enabled
 		return nil
 	}
 }

--- a/core/state/config.go
+++ b/core/state/config.go
@@ -67,10 +67,12 @@ type AgentConfig struct {
 	IdentityGuidance      string `json:"identity_guidance" form:"identity_guidance"`
 	PeriodicRuns          string `json:"periodic_runs" form:"periodic_runs"`
 	PermanentGoal         string `json:"permanent_goal" form:"permanent_goal"`
-	EnableKnowledgeBase    bool   `json:"enable_kb" form:"enable_kb"`
-	EnableKBCompaction     bool   `json:"enable_kb_compaction" form:"enable_kb_compaction"`
-	KBCompactionInterval   string `json:"kb_compaction_interval" form:"kb_compaction_interval"`
-	KBCompactionSummarize  bool   `json:"kb_compaction_summarize" form:"kb_compaction_summarize"`
+	EnableKnowledgeBase   bool   `json:"enable_kb" form:"enable_kb"`
+	EnableKBCompaction    bool   `json:"enable_kb_compaction" form:"enable_kb_compaction"`
+	KBCompactionInterval  string `json:"kb_compaction_interval" form:"kb_compaction_interval"`
+	KBCompactionSummarize bool   `json:"kb_compaction_summarize" form:"kb_compaction_summarize"`
+	KBAutoSearch          bool   `json:"kb_auto_search" form:"kb_auto_search"`
+	KBAsTools             bool   `json:"kb_as_tools" form:"kb_as_tools"`
 	EnableReasoning       bool   `json:"enable_reasoning" form:"enable_reasoning"`
 	EnableGuidedTools     bool   `json:"enable_guided_tools" form:"enable_guided_tools"`
 	KnowledgeBaseResults  int    `json:"kb_results" form:"kb_results"`
@@ -253,6 +255,22 @@ func NewAgentConfigMeta(
 				Label:        "Summary Long Term Memory",
 				Type:         "checkbox",
 				DefaultValue: false,
+				Tags:         config.Tags{Section: "MemorySettings"},
+			},
+			{
+				Name:         "kb_auto_search",
+				Label:        "KB Auto Search",
+				Type:         "checkbox",
+				DefaultValue: true,
+				HelpText:     "Automatically search knowledge base when a user message is received",
+				Tags:         config.Tags{Section: "MemorySettings"},
+			},
+			{
+				Name:         "kb_as_tools",
+				Label:        "KB As Tools",
+				Type:         "checkbox",
+				DefaultValue: false,
+				HelpText:     "Inject knowledge base search and add actions as tools, allowing the agent to access its memory without manual configuration",
 				Tags:         config.Tags{Section: "MemorySettings"},
 			},
 			{


### PR DESCRIPTION
This allows to configure specifically how the Knowledge base should be accessible to the agent.

- Auto search: When enabled, every message will trigger a search to the knowledge base. This is useful mostly if you mean to give immediate context to the agent. Particularly suited for search agents.
- As tools: it will inject search and add tools to the knowledge base so the agent can handle these autonomously.