### PR TITLE
chore: drop agents avatars

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,6 @@ services:
     command: 
     - ${MODEL_NAME:-gemma-3-4b-it-qat}
     - ${MULTIMODAL_MODEL:-gemma-3-4b-it-qat}
-    - ${IMAGE_MODEL:-Z-Image-Turbo}
     - granite-embedding-107m-multilingual
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/readyz"]
@@ -115,7 +114,6 @@ services:
     environment:
       - LOCALAGI_MODEL=${MODEL_NAME:-gemma-3-4b-it-qat}
       - LOCALAGI_MULTIMODAL_MODEL=${MULTIMODAL_MODEL:-moondream2-20250414}
-      - LOCALAGI_IMAGE_MODEL=${IMAGE_MODEL:-Z-Image-Turbo}
       - LOCALAGI_LLM_API_URL=http://localai:8080
       #- LOCALAGI_LLM_API_KEY=sk-1234567890
       - LOCALAGI_LOCALRAG_URL=http://localrecall:8080

--- a/main.go
+++ b/main.go
@@ -23,7 +23,6 @@ var stateDir = os.Getenv("LOCALAGI_STATE_DIR")
 var localRAG = os.Getenv("LOCALAGI_LOCALRAG_URL")
 var withLogs = os.Getenv("LOCALAGI_ENABLE_CONVERSATIONS_LOGGING") == "true"
 var apiKeysEnv = os.Getenv("LOCALAGI_API_KEYS")
-var imageModel = os.Getenv("LOCALAGI_IMAGE_MODEL")
 var conversationDuration = os.Getenv("LOCALAGI_CONVERSATION_DURATION")
 var customActionsDir = os.Getenv("LOCALAGI_CUSTOM_ACTIONS_DIR")
 var sshBoxURL = os.Getenv("LOCALAGI_SSHBOX_URL")
@@ -64,7 +63,6 @@ func main() {
 		transcriptionModel,
 		transcriptionLanguage,
 		ttsModel,
-		imageModel,
 		apiURL,
 		apiKey,
 		stateDir,

--- a/webui/react-ui/src/App.css
+++ b/webui/react-ui/src/App.css
@@ -548,15 +548,19 @@ a:hover {
 
 /* Status Badges */
 .status-badge {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
   padding: 0.25rem 0.75rem;
   border-radius: var(--radius-full);
   font-size: 0.75rem;
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.5px;
+  display: inline-block;
+}
+
+.card .status-badge {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
 }
 
 .status-active,
@@ -683,32 +687,9 @@ a:hover {
 }
 
 /* Agents Grid */
-.agents-grid {
-  display: grid;
-  grid-template-columns: repeat(1, 1fr);
-  gap: 1.25rem;
-}
 
-@media (min-width: 768px) {
-  .agents-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
 
-@media (min-width: 1024px) {
-  .agents-grid {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
 
-.recent-agents {
-  margin-top: 3rem;
-}
-
-.recent-agents h2 {
-  margin-bottom: 1.5rem;
-  text-align: center;
-}
 
 /* ===================================
    HOME PAGE
@@ -728,28 +709,7 @@ a:hover {
   transform: scale(1.02);
 }
 
-/* Avatar Placeholder */
-.avatar-placeholder {
-  width: 80px;
-  height: 80px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: var(--color-bg-tertiary);
-  color: var(--color-primary);
-  font-size: 1.5rem;
-  margin-bottom: 1rem;
-  border: 2px solid var(--color-primary-border);
-}
 
-.avatar-container {
-  margin-bottom: 1rem;
-}
-
-.placeholder-text {
-  z-index: 1;
-}
 
 /* ===================================
    FORMS & INPUTS
@@ -1530,5 +1490,86 @@ select.form-control {
 
   .chat-main {
     height: 400px;
+  }
+}
+
+/* ===================================
+   AGENTS TABLE
+   =================================== */
+
+.agents-table-container {
+  width: 100%;
+  overflow-x: auto;
+  background-color: var(--color-bg-secondary);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  margin-bottom: 2rem;
+}
+
+.agents-table {
+  width: 100%;
+  border-collapse: collapse;
+  text-align: left;
+  min-width: 800px;
+}
+
+.agents-table th {
+  background-color: var(--color-bg-primary);
+  color: var(--color-text-secondary);
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--color-border);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.agents-table td {
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--color-border);
+  vertical-align: middle;
+  transition: background-color var(--duration-fast);
+}
+
+.agents-table tr:last-child td {
+  border-bottom: none;
+}
+
+.agents-table tr:hover td {
+  background-color: var(--color-primary-light);
+}
+
+.agent-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.agent-name-main {
+  font-weight: 600;
+  color: var(--color-primary);
+  font-size: 1.1rem;
+}
+
+.agent-table-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.agent-table-actions .action-btn {
+  padding: 0.4rem 0.75rem;
+  font-size: 0.8rem;
+}
+
+/* Mobile responsive adjustments */
+@media (max-width: 768px) {
+  .agents-table-container {
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
   }
 }

--- a/webui/react-ui/src/pages/AgentsList.jsx
+++ b/webui/react-ui/src/pages/AgentsList.jsx
@@ -17,7 +17,7 @@ function AgentsList() {
       if (!response.ok) {
         throw new Error(`Server responded with status: ${response.status}`);
       }
-      
+
       const data = await response.json();
       setAgents(data.agents || []);
       setStatuses(data.statuses || {});
@@ -38,18 +38,18 @@ function AgentsList() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({}),
       });
-      
+
       if (response.ok) {
         // Update local state
         setStatuses(prev => ({
           ...prev,
           [name]: !isActive
         }));
-        
+
         // Show success toast
         const action = isActive ? 'paused' : 'started';
         showToast(`Agent "${name}" ${action} successfully`, 'success');
-        
+
         // Refresh the agents list to ensure we have the latest data
         fetchAgents();
       } else {
@@ -67,13 +67,13 @@ function AgentsList() {
     if (!confirm(`Are you sure you want to delete agent "${name}"? This action cannot be undone.`)) {
       return;
     }
-    
+
     try {
       const response = await fetch(`/api/agent/${name}`, {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
       });
-      
+
       if (response.ok) {
         // Remove from local state
         setAgents(prev => prev.filter(agent => agent !== name));
@@ -82,7 +82,7 @@ function AgentsList() {
           delete newStatuses[name];
           return newStatuses;
         });
-        
+
         // Show success toast
         showToast(`Agent "${name}" deleted successfully`, 'success');
       } else {
@@ -130,76 +130,69 @@ function AgentsList() {
       </header>
 
       {agents.length > 0 ? (
-        <div className="agents-grid">
-          {agents.map(name => (
-            <div key={name} className="agent-card" data-agent={name} data-active={statuses[name]}>
-              <div className="agent-content text-center">
-                <div className="avatar-container mb-4">
-                  <img 
-                    src={`/avatars/${name}.png`} 
-                    alt={name} 
-                    className="w-24 h-24 rounded-full" 
-                    style={{
-                      border: '2px solid var(--primary)', 
-                      boxShadow: 'var(--neon-glow)', 
-                      display: 'none',
-                      margin: '0 auto'
-                    }}
-                    onLoad={(e) => {
-                      e.target.style.display = 'block';
-                      e.target.nextElementSibling.style.display = 'none';
-                    }}
-                    onError={(e) => {
-                      e.target.style.display = 'none';
-                      e.target.nextElementSibling.style.display = 'flex';
-                    }}
-                  />
-                  <div className="avatar-placeholder" style={{margin: '0 auto'}}>
-                    <span className="placeholder-text"><i className="fas fa-sync fa-spin"></i></span>
-                  </div>
-                </div>
-                
-                <div className="agent-header">
-                  <h2>{name}</h2>
-                  <span className={`status-badge ${statuses[name] ? 'active' : 'inactive'}`}>
-                    {statuses[name] ? 'Active' : 'Paused'}
-                  </span>
-                </div>
-              
-                <div className="agent-actions">
-                  <Link to={`/talk/${name}`} className="action-btn chat-btn">
-                    <i className="fas fa-comment"></i> Chat
-                  </Link>
-                  <Link to={`/status/${name}`} className="action-btn status-btn">
-                    <i className="fas fa-chart-line"></i> Status
-                  </Link>
-                  <Link to={`/settings/${name}`} className="action-btn settings-btn">
-                    <i className="fas fa-cog"></i> Settings
-                  </Link>
-                </div>
-                
-                <div className="agent-actions mt-2">
-                  <button 
-                    className="action-btn toggle-btn"
-                    onClick={() => toggleAgentStatus(name, statuses[name])}
-                  >
-                    {statuses[name] ? (
-                      <><i className="fas fa-pause"></i> Pause</>
-                    ) : (
-                      <><i className="fas fa-play"></i> Start</>
-                    )}
-                  </button>
-                  
-                  <button 
-                    className="action-btn delete-btn"
-                    onClick={() => deleteAgent(name)}
-                  >
-                    <i className="fas fa-trash-alt"></i> Delete
-                  </button>
-                </div>
-              </div>
-            </div>
-          ))}
+        <div className="agents-table-container">
+          <table className="agents-table">
+            <thead>
+              <tr>
+                <th>Agent Name</th>
+                <th>Status</th>
+                <th>Quick Actions</th>
+                <th>Management</th>
+              </tr>
+            </thead>
+            <tbody>
+              {agents.map(name => (
+                <tr key={name} data-agent={name} data-active={statuses[name]}>
+                  <td>
+                    <div className="agent-info">
+                      <span className="agent-name-main">{name}</span>
+                    </div>
+                  </td>
+                  <td>
+                    <span className={`status-badge ${statuses[name] ? 'active' : 'inactive'}`}>
+                      {statuses[name] ? 'Active' : 'Paused'}
+                    </span>
+                  </td>
+                  <td>
+                    <div className="agent-table-actions">
+                      <Link to={`/talk/${name}`} className="action-btn chat-btn" title="Chat">
+                        <i className="fas fa-comment"></i> Chat
+                      </Link>
+                      <Link to={`/status/${name}`} className="action-btn status-btn" title="Status">
+                        <i className="fas fa-chart-line"></i> Status
+                      </Link>
+                      <Link to={`/settings/${name}`} className="action-btn settings-btn" title="Settings">
+                        <i className="fas fa-cog"></i> Settings
+                      </Link>
+                    </div>
+                  </td>
+                  <td>
+                    <div className="agent-table-actions">
+                      <button
+                        className="action-btn toggle-btn"
+                        onClick={() => toggleAgentStatus(name, statuses[name])}
+                        title={statuses[name] ? "Pause Agent" : "Start Agent"}
+                      >
+                        {statuses[name] ? (
+                          <><i className="fas fa-pause"></i> Pause</>
+                        ) : (
+                          <><i className="fas fa-play"></i> Start</>
+                        )}
+                      </button>
+
+                      <button
+                        className="action-btn delete-btn"
+                        onClick={() => deleteAgent(name)}
+                        title="Delete Agent"
+                      >
+                        <i className="fas fa-trash-alt"></i> Delete
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       ) : (
         <div className="no-agents">

--- a/webui/react-ui/src/pages/Home.jsx
+++ b/webui/react-ui/src/pages/Home.jsx
@@ -59,9 +59,9 @@ function Home() {
       <div className="image-container">
         <img src="/app/logo_1.png" width="250" alt="LocalAGI Logo" />
       </div>
-      
+
       {/*<h1 className="dashboard-title">LocalAGI</h1>*/}
-      
+
       {/* Dashboard Stats */}
       <div className="dashboard-stats">
         <div className="stat-item">
@@ -87,7 +87,7 @@ function Home() {
             <p>View and manage your list of agents, including detailed profiles and statistics.</p>
           </div>
         </Link>
-        
+
         {/* Card for Create Agent */}
         <Link to="/create" className="card-link">
           <div className="card">
@@ -95,7 +95,7 @@ function Home() {
             <p>Create a new intelligent agent with custom behaviors, connectors, and actions.</p>
           </div>
         </Link>
-        
+
         {/* Card for Actions Playground */}
         <Link to="/actions-playground" className="card-link">
           <div className="card">
@@ -103,7 +103,7 @@ function Home() {
             <p>Explore and test available actions for your agents.</p>
           </div>
         </Link>
-        
+
         {/* Card for Group Create */}
         <Link to="/group-create" className="card-link">
           <div className="card">
@@ -122,32 +122,6 @@ function Home() {
 
       </div>
 
-      {stats.agents.length > 0 && (
-        <div className="recent-agents">
-          <h2>Your Agents</h2>
-          <div className="cards-container">
-            {stats.agents.map((agent) => (
-              <div key={agent} className="card">
-                <div className={`status-badge ${stats.status[agent] ? 'status-active' : 'status-paused'}`}>
-                  {stats.status[agent] ? 'Active' : 'Paused'}
-                </div>
-                <h2><i className="fas fa-robot"></i> {agent}</h2>
-                <div className="agent-actions">
-                  <Link to={`/talk/${agent}`} className="action-btn chat-btn">
-                    <i className="fas fa-comment"></i> Chat
-                  </Link>
-                  <Link to={`/settings/${agent}`} className="action-btn settings-btn">
-                    <i className="fas fa-cog"></i> Settings
-                  </Link>
-                  <Link to={`/status/${agent}`} className="action-btn status-btn">
-                    <i className="fas fa-chart-line"></i> Status
-                  </Link>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/webui/react-ui/vite.config.js
+++ b/webui/react-ui/vite.config.js
@@ -29,8 +29,7 @@ export default defineConfig(({ mode }) => {
         '/chat': backendUrl,
         '/status': backendUrl,
         '/action': backendUrl,
-        '/actions': backendUrl,
-        '/avatars': backendUrl
+        '/actions': backendUrl
       }
     }
   }

--- a/webui/routes.go
+++ b/webui/routes.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
-	"path/filepath"
 
 	"github.com/dave-gray101/v2keyauth"
 	fiber "github.com/gofiber/fiber/v2"
@@ -26,13 +25,6 @@ import (
 var reactUI embed.FS
 
 func (app *App) registerRoutes(pool *state.AgentPool, webapp *fiber.App) {
-
-	// Static avatars in a.pooldir/avatars
-	webapp.Use("/avatars", filesystem.New(filesystem.Config{
-		Root: http.Dir(filepath.Join(app.config.StateDir, "avatars")),
-		//	PathPrefix: "avatars",
-		Browse: true,
-	}))
 
 	if len(app.config.ApiKeys) > 0 {
 		kaConfig, err := GetKeyAuthConfig(app.config.ApiKeys)


### PR DESCRIPTION
This functionality makes LocalAGI harder to starts without no real gain. While having agents avatars is nice, on generating a new agent is required a new image to be created, which, on small HW could become a huge computational strain.

It moves the agent list view to tabular, and cleanups the index page to improve readability.

We can go back at this, but the motivations are mainly:

- Do not waste computation and be more lightweight
- Less models to download unless the user wants to download image models
- Let's not make look the application "weird" as images could be generated which are not good looking at all

<img width="1602" height="463" alt="Schermata del 2026-02-09 18-59-15" src="https://github.com/user-attachments/assets/f9ab0123-09d7-402a-abc5-f462b00d94c7" />
