### PR TITLE
feat: add accumulator to print tool status/results during execution

### DIFF
--- a/services/connectors/common/status.go
+++ b/services/connectors/common/status.go
@@ -1,0 +1,101 @@
+package common
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mudler/LocalAGI/core/types"
+)
+
+const (
+	// MaxParamsLen is the maximum length for params in "Calling tool X with parameters: ..."
+	MaxParamsLen = 400
+	// MaxResultLen is the maximum length for result in "Result of X: ..."
+	MaxResultLen = 500
+)
+
+// StatusAccumulator holds accumulated status lines for a job's placeholder message.
+// Callers (connectors) are responsible for mutex and for clearing when the job ends.
+type StatusAccumulator struct {
+	lines []string
+}
+
+// NewStatusAccumulator returns a new accumulator.
+func NewStatusAccumulator() *StatusAccumulator {
+	return &StatusAccumulator{lines: nil}
+}
+
+// AppendReasoning appends a "Current thought: ..." line when reasoning is non-empty.
+func (a *StatusAccumulator) AppendReasoning(reasoning string) {
+	if reasoning == "" {
+		return
+	}
+	a.lines = append(a.lines, "Current thought process:\n"+reasoning)
+}
+
+// AppendToolCall appends a "Calling tool X with parameters: ..." line (params truncated).
+func (a *StatusAccumulator) AppendToolCall(actionName string, params string) {
+	if actionName == "" {
+		actionName = "Tool"
+	}
+	truncated := Truncate(params, MaxParamsLen)
+	a.lines = append(a.lines, fmt.Sprintf("Calling tool `%s` with parameters: %s", actionName, truncated))
+}
+
+// AppendToolResult appends a "Result of X: ..." line (result truncated).
+func (a *StatusAccumulator) AppendToolResult(actionName string, result string) {
+	if actionName == "" {
+		actionName = "Tool"
+	}
+	truncated := Truncate(result, MaxResultLen)
+	a.lines = append(a.lines, fmt.Sprintf("Result of `%s`: %s", actionName, truncated))
+}
+
+// BuildMessage returns thinkingPrefix + "\n\n" + joined lines, truncated to maxTotalLen if needed.
+// If over the limit, the message is truncated from the start (oldest content dropped) so the latest lines stay visible.
+func (a *StatusAccumulator) BuildMessage(thinkingPrefix string, maxTotalLen int) string {
+	if len(a.lines) == 0 {
+		return thinkingPrefix
+	}
+	body := strings.Join(a.lines, "\n\n")
+	full := thinkingPrefix + "\n\n" + body
+	if maxTotalLen <= 0 || len(full) <= maxTotalLen {
+		return full
+	}
+	// Keep prefix and truncate from the start of the body
+	available := maxTotalLen - len(thinkingPrefix) - 2 // 2 for "\n\n"
+	if available <= 0 {
+		return Truncate(full, maxTotalLen)
+	}
+	if len(body) <= available {
+		return full
+	}
+	// Drop oldest lines until we fit
+	for i := 0; i < len(a.lines); i++ {
+		trimmed := strings.Join(a.lines[i:], "\n\n")
+		if len(trimmed) <= available {
+			return thinkingPrefix + "\n\n" + trimmed
+		}
+	}
+	// Single line too long
+	return thinkingPrefix + "\n\n" + Truncate(body, available)
+}
+
+// Truncate returns s truncated to maxLen with "..." suffix if truncated.
+func Truncate(s string, maxLen int) string {
+	if maxLen <= 0 || len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-3] + "..."
+}
+
+// ActionDisplayName returns the action's display name for status messages, or "Tool" if nil.
+func ActionDisplayName(action types.Action) string {
+	if action == nil {
+		return "Tool"
+	}
+	return action.Definition().Name.String()
+}


### PR DESCRIPTION
This pull request introduces a new `StatusAccumulator` utility to improve how status messages are tracked and updated for jobs in both Slack and Telegram connectors. The main goal is to provide more granular, readable, and up-to-date placeholder messages for ongoing jobs, including reasoning steps and tool calls/results. The implementation ensures thread-safe updates and proper cleanup of status tracking. The most important changes are grouped below:

### New StatusAccumulator utility

* Added `common/status.go` with the `StatusAccumulator` struct and related methods for accumulating, truncating, and formatting status lines for job messages. This includes helpers for appending reasoning, tool calls, and results, and for building the final message with truncation logic.

### Integration with Slack connector

* Updated the Slack connector to use `StatusAccumulator` for each job, storing accumulators in a new `jobStatus` map and updating placeholder messages with detailed reasoning and tool call/result information. Mutex handling was changed to ensure thread safety during updates and cleanup. [[1]](diffhunk://#diff-4ee181e4ac255ed2b8de30f39d73ec18f7c5e603bdfdda87e3466625f9c205d7R21) [[2]](diffhunk://#diff-4ee181e4ac255ed2b8de30f39d73ec18f7c5e603bdfdda87e3466625f9c205d7R40) [[3]](diffhunk://#diff-4ee181e4ac255ed2b8de30f39d73ec18f7c5e603bdfdda87e3466625f9c205d7R58-R91) [[4]](diffhunk://#diff-4ee181e4ac255ed2b8de30f39d73ec18f7c5e603bdfdda87e3466625f9c205d7L76-L100) [[5]](diffhunk://#diff-4ee181e4ac255ed2b8de30f39d73ec18f7c5e603bdfdda87e3466625f9c205d7L766-R804)

### Integration with Telegram connector

* Updated the Telegram connector to use `StatusAccumulator` for each job, storing accumulators in a new `jobStatus` map and updating placeholder messages with detailed reasoning and tool call/result information. Mutex handling was changed to ensure thread safety during updates and cleanup. [[1]](diffhunk://#diff-34f0891668daee7c5fbe1f8fd2be336ee7da1f8a13138c86429fe9bc8dae2131R25) [[2]](diffhunk://#diff-34f0891668daee7c5fbe1f8fd2be336ee7da1f8a13138c86429fe9bc8dae2131R45) [[3]](diffhunk://#diff-34f0891668daee7c5fbe1f8fd2be336ee7da1f8a13138c86429fe9bc8dae2131L309-R314) [[4]](diffhunk://#diff-34f0891668daee7c5fbe1f8fd2be336ee7da1f8a13138c86429fe9bc8dae2131L426-L464) [[5]](diffhunk://#diff-34f0891668daee7c5fbe1f8fd2be336ee7da1f8a13138c86429fe9bc8dae2131L780-R820) [[6]](diffhunk://#diff-34f0891668daee7c5fbe1f8fd2be336ee7da1f8a13138c86429fe9bc8dae2131R1062)

These changes collectively provide a more informative and user-friendly experience for job status updates in both Slack and Telegram integrations.