### PR TITLE
allow configuring LOCALAGI to use a custom base url

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,8 @@ LocalAGI supports environment configurations. Note that these environment variab
 | `LOCALAGI_LLM_API_KEY` | API authentication |
 | `LOCALAGI_TIMEOUT` | Request timeout settings |
 | `LOCALAGI_STATE_DIR` | Where state gets stored |
-| `LOCALAGI_BASE_URL` | Optional base URL for the app (only relevant when using an external LocalRAG URL; not used for built-in knowledge base) |
+| `LOCALAGI_LOCALRAG_URL` | Optional URL when using an external LocalRAG URL; not used for built-in knowledge base |
+| `LOCALAGI_BASE_URL` | Optional base URL for the app (defaults to ":3000") |
 | `LOCALAGI_ENABLE_CONVERSATIONS_LOGGING` | Toggle conversation logs |
 | `LOCALAGI_API_KEYS` | A comma separated list of api keys used for authentication |
 | `LOCALAGI_CUSTOM_ACTIONS_DIR` | Directory containing custom Go action files to be automatically loaded |
@@ -1049,7 +1050,8 @@ LocalAGI supports environment configurations. Note that these environment variab
 | `LOCALAGI_LLM_API_KEY` | API authentication |
 | `LOCALAGI_TIMEOUT` | Request timeout settings |
 | `LOCALAGI_STATE_DIR` | Where state gets stored |
-| `LOCALAGI_BASE_URL` | Optional base URL for built-in knowledge base (default `http://localhost:3000`) |
+| `LOCALAGI_LOCALRAG_URL` | Optional URL when using an external LocalRAG URL; not used for built-in knowledge base |
+| `LOCALAGI_BASE_URL` | Optional base URL for the app (defaults to ":3000") |
 | `LOCALAGI_SSHBOX_URL` | LocalAGI SSHBox URL, e.g. user:pass@ip:port |
 | `LOCALAGI_ENABLE_CONVERSATIONS_LOGGING` | Toggle conversation logs |
 | `LOCALAGI_API_KEYS` | A comma separated list of api keys used for authentication |

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -20,6 +20,7 @@ type Env struct {
 	
 	// Directories and paths
 	StateDir                string
+	LocalAGIURL             string
 	LocalRAGURL             string
 	CustomActionsDir        string
 	SSHBoxURL               string
@@ -51,6 +52,7 @@ func LoadEnv() Env {
 		TTSModel:                 envOrDefault("LOCALAGI_TTS_MODEL", ""),
 		Timeout:                  envOrDefault("LOCALAGI_TIMEOUT", "5m"),
 		StateDir:                 envOrDefault("LOCALAGI_STATE_DIR", ""),
+		LocalAGIURL:              envOrDefault("LOCALAGI_BASE_URL", ":3000"),
 		LocalRAGURL:              os.Getenv("LOCALAGI_LOCALRAG_URL"),
 		CustomActionsDir:         os.Getenv("LOCALAGI_CUSTOM_ACTIONS_DIR"),
 		SSHBoxURL:                os.Getenv("LOCALAGI_SSHBOX_URL"),

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -123,6 +123,6 @@ func runServe(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	log.Fatal(app.Listen(":3000"))
+	log.Fatal(app.Listen(env.LocalAGIURL))
 	return nil
 }

--- a/webui/react-ui/vite.config.js
+++ b/webui/react-ui/vite.config.js
@@ -6,7 +6,7 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
 
   // Define backend URL with port from environment variable or default to 8080
-  const backendUrl = `http://${env.BACKEND_HOST || 'localhost'}:${env.BACKEND_PORT || '3000'}`
+  const backendUrl = `http://${env.LOCALAGI_BASE_URL || 'localhost:3000'}`
 
   return {
     plugins: [react()],


### PR DESCRIPTION
Allow a customer base URL for LocalAGI using environment variable **LOCALAGI_BASE_URL**. Defaults to **":3000"** which is the hardcoded address at the moment.

Update README.md accordingly, in particular to distinguish **LOCALAGI_LOCALRAG_URL** from **LOCALAGI_BASE_URL**, I think there is a mix up between the two in the current documentation, where **LOCALAGI_BASE_URL** is described to affect the RAG URL (but doesn't actually do anything), while **LOCALAGI_LOCALRAG_URL** is implemented but not described in the README.