### PR TITLE
fix(sse): preserve broadcast order and de-race message history

### DIFF
--- a/core/sse/sse.go
+++ b/core/sse/sse.go
@@ -95,10 +95,16 @@ type broadcastManager struct {
 }
 
 // NewManager initializes and returns a new Manager instance.
-func NewManager(workerPoolSize int) Manager {
+// bufferSize sets the broadcast channel capacity so Send() rarely blocks;
+// delivery itself is handled by a single goroutine to preserve message order
+// (SSE consumers rely on it, e.g. for token streams).
+func NewManager(bufferSize int) Manager {
+	if bufferSize < 1 {
+		bufferSize = 1
+	}
 	manager := &broadcastManager{
-		broadcast:      make(chan Envelope),
-		workerPoolSize: workerPoolSize,
+		broadcast:      make(chan Envelope, bufferSize*16),
+		workerPoolSize: bufferSize,
 		messageHistory: newHistory(10),
 	}
 
@@ -176,27 +182,36 @@ func (manager *broadcastManager) Clients() []string {
 	return clients
 }
 
-// startWorkers starts worker goroutines for message broadcasting.
+// startWorkers starts the delivery goroutine for message broadcasting.
+//
+// Delivery is intentionally single-threaded: a pool of competing workers on
+// the same channel delivers messages to clients in nondeterministic order,
+// which scrambles token-level SSE streams (observed as interleaved/corrupted
+// chat output in the UI). One goroutine consuming a buffered channel keeps
+// FIFO order end-to-end; per-client backpressure is still handled by the
+// non-blocking send below (slow clients drop messages instead of stalling
+// everyone else).
 func (manager *broadcastManager) startWorkers() {
-	for i := 0; i < manager.workerPoolSize; i++ {
-		go func() {
-			for message := range manager.broadcast {
-				manager.clients.Range(func(key, value any) bool {
-					client, ok := value.(Listener)
-					if !ok {
-						return true // Continue iteration
-					}
-					select {
-					case client.Chan() <- message:
-						manager.messageHistory.Add(message)
-					default:
-						// If the client's channel is full, drop the message
-					}
+	go func() {
+		for message := range manager.broadcast {
+			// Record once per message — not once per delivered client —
+			// so history stays duplicate-free and is kept even when no
+			// client is currently connected.
+			manager.messageHistory.Add(message)
+			manager.clients.Range(func(key, value any) bool {
+				client, ok := value.(Listener)
+				if !ok {
 					return true // Continue iteration
-				})
-			}
-		}()
-	}
+				}
+				select {
+				case client.Chan() <- message:
+				default:
+					// If the client's channel is full, drop the message
+				}
+				return true // Continue iteration
+			})
+		}
+	}()
 }
 
 // register adds a client to the manager.
@@ -210,6 +225,7 @@ func (manager *broadcastManager) unregister(clientID string) {
 }
 
 type history struct {
+	mu       sync.Mutex
 	messages []Envelope
 	maxSize  int // Maximum number of messages to retain
 }
@@ -222,6 +238,8 @@ func newHistory(maxSize int) *history {
 }
 
 func (h *history) Add(message Envelope) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	h.messages = append(h.messages, message)
 	// Ensure history does not exceed maxSize
 	if len(h.messages) > h.maxSize {
@@ -230,8 +248,21 @@ func (h *history) Add(message Envelope) {
 	}
 }
 
+// Send replays the retained history to a client. It snapshots the messages
+// under the lock but delivers outside of it: the client channel is written
+// from the connection handler's goroutine while the delivery goroutine may
+// concurrently Add, so holding the lock across channel sends could deadlock
+// a full client against the broadcaster.
 func (h *history) Send(c Listener) {
-	for _, msg := range h.messages {
-		c.Chan() <- msg
+	h.mu.Lock()
+	snapshot := make([]Envelope, len(h.messages))
+	copy(snapshot, h.messages)
+	h.mu.Unlock()
+	for _, msg := range snapshot {
+		select {
+		case c.Chan() <- msg:
+		default:
+			// Drop replayed history for clients whose buffer is already full.
+		}
 	}
 }

--- a/core/sse/sse_test.go
+++ b/core/sse/sse_test.go
@@ -1,0 +1,114 @@
+package sse
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// drainOrdered reads n messages from the client and fails the test on the
+// first out-of-order or missing message.
+func drainOrdered(t *testing.T, cl Listener, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		select {
+		case msg := <-cl.Chan():
+			want := fmt.Sprintf("data: %d\n\n", i)
+			if msg.String() != want {
+				t.Fatalf("message %d out of order: got %q, want %q", i, msg.String(), want)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for message %d", i)
+		}
+	}
+}
+
+// TestBroadcastPreservesOrder guards the FIFO guarantee of the broadcast
+// path: token-level SSE streams (agent chat deltas) are only meaningful in
+// send order. A delivery worker pool with >1 goroutine reorders messages
+// under scheduling pressure, which surfaced as interleaved/corrupted chat
+// streams in the UI.
+func TestBroadcastPreservesOrder(t *testing.T) {
+	manager := NewManager(5)
+
+	// Buffer must hold the full sequence: the non-blocking delivery drops
+	// messages for slow clients, which is not what we test here.
+	const total = 40 // fits within the client channel buffer (50)
+	cl := NewClient("order-test")
+	manager.Register(cl)
+
+	for i := 0; i < total; i++ {
+		manager.Send(NewMessage(fmt.Sprintf("%d", i)))
+	}
+
+	drainOrdered(t, cl, total)
+}
+
+// TestHistoryReplayedOnceWithoutDuplicates ensures a message entering the
+// broadcast is recorded in history exactly once, independent of how many
+// clients are connected (it used to be added once per delivered client).
+func TestHistoryReplayedOnceWithoutDuplicates(t *testing.T) {
+	manager := NewManager(1)
+
+	a := NewClient("a")
+	b := NewClient("b")
+	manager.Register(a)
+	manager.Register(b)
+
+	manager.Send(NewMessage("only-once"))
+
+	// Wait until both connected clients received the live message, which
+	// proves the delivery goroutine has processed it into history too.
+	for _, cl := range []Listener{a, b} {
+		select {
+		case <-cl.Chan():
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for live delivery")
+		}
+	}
+
+	late := NewClient("late")
+	manager.Register(late) // Register replays history
+
+	got := 0
+	for {
+		select {
+		case <-late.Chan():
+			got++
+		case <-time.After(200 * time.Millisecond):
+			if got != 1 {
+				t.Fatalf("late client received %d replayed messages, want 1", got)
+			}
+			return
+		}
+	}
+}
+
+// TestHistoryKeptWithoutClients ensures messages broadcast while nobody is
+// connected still land in history and are replayed to the next client.
+func TestHistoryKeptWithoutClients(t *testing.T) {
+	manager := NewManager(1)
+
+	manager.Send(NewMessage("while-alone"))
+
+	// Give the delivery goroutine a moment to process the message.
+	deadline := time.After(5 * time.Second)
+	for {
+		cl := NewClient("first")
+		manager.Register(cl)
+		select {
+		case msg := <-cl.Chan():
+			if msg.String() != "data: while-alone\n\n" {
+				t.Fatalf("unexpected replayed message: %q", msg.String())
+			}
+			return
+		case <-time.After(50 * time.Millisecond):
+			manager.Unregister(cl.ID())
+			select {
+			case <-deadline:
+				t.Fatal("message sent without clients never reached history")
+			default:
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

The SSE broadcast manager runs a pool of N competing delivery workers (`NewManager(5)` in `core/state/pool.go`) on a single broadcast channel. Each message is handed to exactly one worker, so with N>1 the delivery order to connected clients depends on goroutine scheduling.

## Why it matters

Token-level SSE streams (`stream_event` chat deltas emitted by the pool's `WithStreamCallback`) are only meaningful in send order. Under real streaming rates the worker pool visibly scrambles them — in the React UI this surfaces as interleaved/corrupted agent chat output (tokens woven out of order, seemingly "multiple answers braided together").

There are two additional defects in the same file:

- `messageHistory.Add()` was called once **per delivered client** inside the per-client loop: with 2 clients each message was recorded twice (duplicated on replay after an `EventSource` reconnect), and with 0 clients nothing was recorded at all. It also raced unsynchronized across the 5 workers (slice append without a mutex).
- `history.Send()` wrote to the client channel blocking, so a client with a full buffer could stall the connection handler.

## Fix

- Single delivery goroutine consuming a buffered channel: FIFO order is preserved end-to-end, `Send()` stays non-blocking in practice, and slow clients still drop messages instead of stalling the broadcast (unchanged semantics).
- History records exactly once per message, under a mutex, independent of connected clients.
- History replay snapshots under the lock and delivers non-blocking.

## Tests

`go test ./core/sse/... -race` — adds order-preservation, history-dedup and history-without-clients tests. The order test fails against the previous worker-pool implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYp5FnAfsdGb6yjLmv8Mge