### PR TITLE
fix(agent): guard against nil user message in knowledgeBaseLookup (nil-pointer panic)

### DIFF
--- a/core/agent/knowledgebase.go
+++ b/core/agent/knowledgebase.go
@@ -41,11 +41,8 @@ func (a *Agent) knowledgeBaseLookup(job *types.Job, conv Messages) Messages {
 
 	// Walk conversation from bottom to top, and find the first message of the user
 	// to use it as a query to the KB
-	userMessage := conv.GetLatestUserMessage().Content
-
-	xlog.Info("[Knowledge Base Lookup] Last user message", "agent", a.Character.Name, "message", userMessage, "lastMessage", conv.GetLatestUserMessage())
-
-	if userMessage == "" {
+	lastUser := conv.GetLatestUserMessage()
+	if lastUser == nil || lastUser.Content == "" {
 		xlog.Info("[Knowledge Base Lookup] No user message found in conversation", "agent", a.Character.Name)
 		if obs != nil {
 			obs.Completion = &types.Completion{
@@ -55,6 +52,9 @@ func (a *Agent) knowledgeBaseLookup(job *types.Job, conv Messages) Messages {
 		}
 		return conv
 	}
+	userMessage := lastUser.Content
+
+	xlog.Info("[Knowledge Base Lookup] Last user message", "agent", a.Character.Name, "message", userMessage)
 
 	results, err := a.options.ragdb.Search(userMessage, a.options.kbResults)
 	if err != nil {


### PR DESCRIPTION
## Problem

`knowledgeBaseLookup` (`core/agent/knowledgebase.go`) dereferences the result of `GetLatestUserMessage()` before checking it for nil:

```go
userMessage := conv.GetLatestUserMessage().Content   // line 44 — panics when nil

xlog.Info("[Knowledge Base Lookup] Last user message", ..., "lastMessage", conv.GetLatestUserMessage())

if userMessage == "" {                                // intended "no user message" handler
    ...
    return conv
}
```

`Messages.GetLatestUserMessage()` (`core/agent/actions.go`) returns `nil` when the conversation has no `user`-role message:

```go
func (m Messages) GetLatestUserMessage() *openai.ChatCompletionMessage {
    for i := len(m) - 1; i >= 0; i-- {
        if m[i].Role == UserRole { msg := m[i]; return &msg }
    }
    return nil
}
```

So line 44 panics with a nil pointer dereference. The function's own `if userMessage == ""` branch is meant to handle exactly this "no user message" case — but it's **unreachable**, because the crash happens first. A non-empty conversation with no user message is a real, anticipated state (e.g. `previous_response_id` continuations that end with an assistant message, or system/assistant-only history). `knowledgeBaseLookup` runs for every job when KB auto-search is enabled (`agent.go:986`).

## Reproduction

`conv = [{system,...}, {assistant,...}]` (no user message):

- **Before:** `runtime error: invalid memory address or nil pointer dereference`
- **After:** reaches the existing "No user message found in conversation" branch and returns cleanly.

(Verified with go1.26 on a standalone reproduction of `GetLatestUserMessage` + the line-44 pattern.)

## Fix

Nil-check before dereferencing so the existing guard runs (and drop the redundant second `GetLatestUserMessage()` call in the log):

```go
lastUser := conv.GetLatestUserMessage()
if lastUser == nil || lastUser.Content == "" {
    xlog.Info("[Knowledge Base Lookup] No user message found in conversation", "agent", a.Character.Name)
    if obs != nil {
        obs.Completion = &types.Completion{Error: "No user message found in conversation"}
        a.observer.Update(*obs)
    }
    return conv
}
userMessage := lastUser.Content
```

`go build ./core/agent/` passes. (The `core/agent` suite expects a live LLM endpoint, so I verified the crash/fix via the standalone repro rather than the full suite.)
