### PR TITLE
fix: service "localagi" refers to undefined volume localagi_pool: invalid compose project

### DIFF
--- a/docker-compose-volumes-include.yaml
+++ b/docker-compose-volumes-include.yaml
@@ -1,0 +1,6 @@
+volumes:
+  postgres_data:
+  models:
+  backends:
+  images:
+  localagi_pool:

--- a/docker-compose.amd.yaml
+++ b/docker-compose.amd.yaml
@@ -25,3 +25,6 @@ services:
     extends:
       file: docker-compose.yaml
       service: localagi
+
+include:
+  - path: docker-compose-volumes-include.yaml

--- a/docker-compose.intel.yaml
+++ b/docker-compose.intel.yaml
@@ -26,3 +26,6 @@ services:
     extends:
       file: docker-compose.yaml
       service: localagi
+
+include:
+  - path: docker-compose-volumes-include.yaml

--- a/docker-compose.nvidia.yaml
+++ b/docker-compose.nvidia.yaml
@@ -31,3 +31,6 @@ services:
     extends:
       file: docker-compose.yaml
       service: localagi
+
+include:
+  - path: docker-compose-volumes-include.yaml

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -104,9 +104,5 @@ services:
       # Optional: mount a host directory for skills (replaces the default state-dir/skills path)
       # - ./skills:/pool/skills
 
-volumes:
-  postgres_data:
-  models:
-  backends:
-  images:
-  localagi_pool:
+include:
+  - path: docker-compose-volumes-include.yaml


### PR DESCRIPTION
fix: service "localagi" refers to undefined volume localagi_pool: invalid compose project

When running docker compose using a compose file other than docker-compose.yaml, e.g. the following example from the README.md
`docker compose -f docker-compose.nvidia.yaml up`
I see the error message:
`service "localagi" refers to undefined volume localagi_pool: invalid compose project`
or sometimes other variations on undefined volume depending on which is attempted first.

The problem occurs because the volumes added to docker-compose.yaml and used by the "extends" to add services to the other files requires the volumes to be added to the other compose files as well.

This PR adds the volumes to a separate file "docker-compose-volumes-include.yaml" and includes that file in all the other docker-compose files so that all the files now have the required volumes defined.