### PR TITLE
fix(core): make JobResult.Finish idempotent

### DIFF
--- a/core/types/result.go
+++ b/core/types/result.go
@@ -32,12 +32,24 @@ func (j *JobResult) SetResult(text ActionState) {
 }
 
 // Finish marks the job as done and closes the ready channel.
+//
+// Finish is idempotent: a job may be finished from more than one code path
+// (for example an early finish inside a tool decision followed by the regular
+// completion). Closing the ready channel twice would panic with
+// "close of closed channel" and take the whole agent down, so the first call
+// wins: its error is kept and its finalizers run; later calls are no-ops.
 func (j *JobResult) Finish(e error) {
 	j.Lock()
-	j.Error = e
+	select {
+	case <-j.ready:
+		// Already finished.
+		j.Unlock()
+		return
+	default:
+		j.Error = e
+		close(j.ready)
+	}
 	j.Unlock()
-
-	close(j.ready)
 
 	for _, f := range j.Finalizers {
 		f(j.Conversation)

--- a/core/types/result_finish_test.go
+++ b/core/types/result_finish_test.go
@@ -1,0 +1,29 @@
+package types
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+// A job finished twice must not panic (close of closed channel); the first
+// error wins and the finalizers run exactly once.
+func TestJobResultFinishIsIdempotent(t *testing.T) {
+	j := NewJobResult()
+	calls := 0
+	j.AddFinalizer(func(c []openai.ChatCompletionMessage) { calls++ })
+	j.Finish(errors.New("first"))
+	j.Finish(nil) // second call: must be a no-op
+	if j.Error == nil || j.Error.Error() != "first" {
+		t.Fatalf("first error must win, got %v", j.Error)
+	}
+	if calls != 1 {
+		t.Fatalf("finalizers must run once, ran %d times", calls)
+	}
+	select {
+	case <-j.ready:
+	default:
+		t.Fatal("ready channel must be closed after Finish")
+	}
+}


### PR DESCRIPTION
## Problem

`JobResult.Finish` unconditionally closes the `ready` channel. A job can legitimately be finished from more than one code path — an early finish inside a tool decision, followed by the regular completion of the job. The second call hits `close(j.ready)` on an already closed channel and panics with `close of closed channel`, which brings the whole agent down.

## Reproduction

```go
j := types.NewJobResult()
j.Finish(errors.New("first"))
j.Finish(nil) // panic: close of closed channel
```

The new test `TestJobResultFinishIsIdempotent` in `core/types/result_finish_test.go` reproduces this; it panics on `main` and passes with this change.

## Fix

`Finish` is now idempotent. Under the job lock it checks whether `ready` is already closed and returns early if so. The first call wins: its error is stored, the channel is closed once, and the finalizers run exactly once. Later calls are no-ops. `WaitResult` and all other callers are unaffected.

## Testing

- `go test ./core/types/...` — fails (panic) without the fix, passes with it
- `go vet ./core/types/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHcZ8CTpZEoK3qgroNnkB4
