### PR TITLE
fix(webui): honor disabled form fields and guard empty agent name on submit

### DIFF
--- a/webui/react-ui/src/components/common/FormField.jsx
+++ b/webui/react-ui/src/components/common/FormField.jsx
@@ -13,6 +13,7 @@ import React from 'react';
  * @param {string} props.helpText Help text to display below the field
  * @param {Array} props.options Options for select inputs
  * @param {boolean} props.required Whether the field is required
+ * @param {boolean} props.disabled Whether the field is read-only for the user
  */
 const FormField = ({
   id,
@@ -28,6 +29,7 @@ const FormField = ({
   min = 0,
   max = 2**31,
   step = 1,
+  disabled = false,
 }) => {
   // Create label with required indicator
   const labelWithIndicator = required ? (
@@ -49,6 +51,7 @@ const FormField = ({
                 name={name}
                 checked={value === true || value === 'true'}
                 onChange={onChange}
+                disabled={disabled}
               />
               {labelWithIndicator}
             </label>
@@ -66,6 +69,7 @@ const FormField = ({
               onChange={onChange}
               className="form-control"
               required={required}
+              disabled={disabled}
             >
               {options.map((option) => (
                 <option key={option.value} value={option.value}>
@@ -89,6 +93,7 @@ const FormField = ({
               placeholder={placeholder}
               required={required}
               rows={5}
+              disabled={disabled}
             />
             {helpText && <small className="form-text text-muted">{helpText}</small>}
           </>
@@ -109,6 +114,7 @@ const FormField = ({
               min={min}
               max={max}
               step={step}
+              disabled={disabled}
             />
             {helpText && <small className="form-text text-muted">{helpText}</small>}
           </>
@@ -126,6 +132,7 @@ const FormField = ({
               className="form-control"
               placeholder={placeholder}
               required={required}
+              disabled={disabled}
             />
             {helpText && <small className="form-text text-muted">{helpText}</small>}
           </>

--- a/webui/react-ui/src/components/common/FormFieldDefinition.jsx
+++ b/webui/react-ui/src/components/common/FormFieldDefinition.jsx
@@ -9,12 +9,14 @@ import FormField from './FormField';
  * @param {Object} props.values Current values for the fields
  * @param {Function} props.onChange Handler for field value changes
  * @param {string} props.idPrefix Prefix for field IDs
+ * @param {boolean} props.disabled Disable every field; a single field can also carry `disabled: true`
  */
 const FormFieldDefinition = ({
   fields,
   values,
   onChange,
   idPrefix = '',
+  disabled = false,
 }) => {
   // Ensure values is an object
   const safeValues = values || {};
@@ -37,6 +39,7 @@ const FormFieldDefinition = ({
             min={field.min || 0}
             max={field.max || 2**31}
             step={field.step || 1}
+            disabled={disabled || field.disabled === true}
           />
         </div>
       ))}

--- a/webui/react-ui/src/pages/CreateAgent.jsx
+++ b/webui/react-ui/src/pages/CreateAgent.jsx
@@ -39,7 +39,7 @@ function CreateAgent() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     
-    if (!formData.name.trim()) {
+    if (!(formData.name || '').trim()) {
       showToast('Agent name is required', 'error');
       return;
     }


### PR DESCRIPTION
## Problem

Two small defects in the React UI agent form:

1. **`disabled` was never forwarded to inputs.** `BasicInfoSection` marks the `name` field as `disabled: true` in edit mode (with the help text "Agent name cannot be changed after creation"), but `FormFieldDefinition` and `FormField` silently dropped the flag. The agent name therefore stayed fully editable on the settings page, contradicting the help text.
2. **Submitting a fresh Create Agent form crashed.** `CreateAgent.handleSubmit` calls `formData.name.trim()`. When the form is submitted without ever typing into the name field, `formData.name` is `undefined` and the handler throws `TypeError: Cannot read properties of undefined (reading 'trim')` instead of showing the "Agent name is required" toast.

## Reproduction

1. Open the settings page of an existing agent: the **Name** input is editable although the help text says it cannot be changed.
2. Open **Create Agent**, leave the name empty, click **Create Agent**: an uncaught `TypeError` appears in the console and no toast is shown.

## Fix

- `FormField` accepts a `disabled` prop and passes it to every rendered input type (text, number, textarea, select, checkbox).
- `FormFieldDefinition` accepts a `disabled` prop and forwards `disabled || field.disabled === true`, so both a form-wide flag and the per-field `disabled: true` that `BasicInfoSection` already emits take effect.
- `CreateAgent` guards the name check with `(formData.name || '').trim()`.

No behavior changes for fields that do not set `disabled`.

## Testing

- `npm run build` (vite) in `webui/react-ui` — builds cleanly
- `eslint` on the three touched files — no new findings (the only report is the pre-existing unused `response` variable in `CreateAgent.jsx`, untouched here)
- Manual check: name field renders as disabled in edit mode; submitting an empty create form now shows the toast instead of throwing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHcZ8CTpZEoK3qgroNnkB4
